### PR TITLE
dts: -pinctrl.dtsi: Label clean up and HSPI signals

### DIFF
--- a/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
@@ -1457,7 +1457,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
@@ -1345,7 +1345,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
@@ -1457,7 +1457,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
@@ -1345,7 +1345,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
@@ -1457,7 +1457,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
@@ -1345,7 +1345,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
@@ -1457,7 +1457,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
@@ -1345,7 +1345,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
@@ -1457,7 +1457,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
@@ -1345,7 +1345,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
@@ -1457,7 +1457,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
@@ -1345,7 +1345,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
@@ -1457,7 +1457,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
@@ -1345,7 +1345,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
@@ -1457,7 +1457,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
@@ -1345,7 +1345,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
@@ -1457,7 +1457,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
@@ -1345,7 +1345,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
@@ -1457,7 +1457,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
@@ -1345,7 +1345,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
@@ -1457,7 +1457,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
@@ -1345,7 +1345,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
@@ -1457,7 +1457,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
@@ -1345,7 +1345,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
@@ -1010,7 +1010,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_clk_pa1: eth1_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF0)>;

--- a/dts/st/mp13/stm32mp131aaex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131aaex-pinctrl.dtsi
@@ -768,6 +768,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {
@@ -1748,6 +1800,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2678,139 +3064,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -2919,128 +3282,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp131aafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131aafx-pinctrl.dtsi
@@ -768,6 +768,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {
@@ -1748,6 +1800,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2678,139 +3064,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -2919,128 +3282,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp131aagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131aagx-pinctrl.dtsi
@@ -768,6 +768,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {
@@ -1748,6 +1800,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2678,139 +3064,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -2919,128 +3282,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp131caex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131caex-pinctrl.dtsi
@@ -768,6 +768,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {
@@ -1748,6 +1800,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2678,139 +3064,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -2919,128 +3282,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp131cafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131cafx-pinctrl.dtsi
@@ -768,6 +768,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {
@@ -1748,6 +1800,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2678,139 +3064,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -2919,128 +3282,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp131cagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131cagx-pinctrl.dtsi
@@ -768,6 +768,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {
@@ -1748,6 +1800,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2678,139 +3064,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -2919,128 +3282,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp131daex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131daex-pinctrl.dtsi
@@ -768,6 +768,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {
@@ -1748,6 +1800,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2678,139 +3064,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -2919,128 +3282,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp131dafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131dafx-pinctrl.dtsi
@@ -768,6 +768,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {
@@ -1748,6 +1800,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2678,139 +3064,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -2919,128 +3282,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp131dagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131dagx-pinctrl.dtsi
@@ -768,6 +768,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {
@@ -1748,6 +1800,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2678,139 +3064,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -2919,128 +3282,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp131faex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131faex-pinctrl.dtsi
@@ -768,6 +768,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {
@@ -1748,6 +1800,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2678,139 +3064,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -2919,128 +3282,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp131fafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131fafx-pinctrl.dtsi
@@ -768,6 +768,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {
@@ -1748,6 +1800,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2678,139 +3064,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -2919,128 +3282,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp131fagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131fagx-pinctrl.dtsi
@@ -768,6 +768,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {
@@ -1748,6 +1800,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2678,139 +3064,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -2919,128 +3282,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp133aaex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133aaex-pinctrl.dtsi
@@ -876,6 +876,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -1912,6 +2014,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2842,139 +3278,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3083,128 +3496,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp133aafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133aafx-pinctrl.dtsi
@@ -876,6 +876,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -1912,6 +2014,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2842,139 +3278,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3083,128 +3496,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp133aagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133aagx-pinctrl.dtsi
@@ -876,6 +876,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -1912,6 +2014,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2842,139 +3278,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3083,128 +3496,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp133caex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133caex-pinctrl.dtsi
@@ -876,6 +876,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -1912,6 +2014,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2842,139 +3278,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3083,128 +3496,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp133cafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133cafx-pinctrl.dtsi
@@ -876,6 +876,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -1912,6 +2014,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2842,139 +3278,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3083,128 +3496,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp133cagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133cagx-pinctrl.dtsi
@@ -876,6 +876,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -1912,6 +2014,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2842,139 +3278,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3083,128 +3496,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp133daex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133daex-pinctrl.dtsi
@@ -876,6 +876,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -1912,6 +2014,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2842,139 +3278,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3083,128 +3496,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp133dafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133dafx-pinctrl.dtsi
@@ -876,6 +876,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -1912,6 +2014,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2842,139 +3278,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3083,128 +3496,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp133dagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133dagx-pinctrl.dtsi
@@ -876,6 +876,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -1912,6 +2014,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2842,139 +3278,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3083,128 +3496,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp133faex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133faex-pinctrl.dtsi
@@ -876,6 +876,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -1912,6 +2014,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2842,139 +3278,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3083,128 +3496,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp133fafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133fafx-pinctrl.dtsi
@@ -876,6 +876,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -1912,6 +2014,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2842,139 +3278,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3083,128 +3496,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp133fagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133fagx-pinctrl.dtsi
@@ -876,6 +876,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -1912,6 +2014,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -2842,139 +3278,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3083,128 +3496,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp135aaex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135aaex-pinctrl.dtsi
@@ -1163,6 +1163,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -2665,6 +2767,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -3595,139 +4031,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3836,128 +4249,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp135aafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135aafx-pinctrl.dtsi
@@ -1163,6 +1163,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -2665,6 +2767,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -3595,139 +4031,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3836,128 +4249,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp135aagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135aagx-pinctrl.dtsi
@@ -1163,6 +1163,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -2665,6 +2767,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -3595,139 +4031,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3836,128 +4249,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp135caex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135caex-pinctrl.dtsi
@@ -1163,6 +1163,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -2665,6 +2767,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -3595,139 +4031,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3836,128 +4249,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp135cafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135cafx-pinctrl.dtsi
@@ -1163,6 +1163,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -2665,6 +2767,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -3595,139 +4031,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3836,128 +4249,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp135cagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135cagx-pinctrl.dtsi
@@ -1163,6 +1163,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -2665,6 +2767,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -3595,139 +4031,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3836,128 +4249,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp135daex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135daex-pinctrl.dtsi
@@ -1163,6 +1163,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -2665,6 +2767,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -3595,139 +4031,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3836,128 +4249,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp135dafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135dafx-pinctrl.dtsi
@@ -1163,6 +1163,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -2665,6 +2767,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -3595,139 +4031,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3836,128 +4249,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp135dagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135dagx-pinctrl.dtsi
@@ -1163,6 +1163,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -2665,6 +2767,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -3595,139 +4031,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3836,128 +4249,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp135faex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135faex-pinctrl.dtsi
@@ -1163,6 +1163,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -2665,6 +2767,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -3595,139 +4031,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3836,128 +4249,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp135fafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135fafx-pinctrl.dtsi
@@ -1163,6 +1163,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -2665,6 +2767,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -3595,139 +4031,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3836,128 +4249,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/mp13/stm32mp135fagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135fagx-pinctrl.dtsi
@@ -1163,6 +1163,108 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH (Extended) */
+
+			/omit-if-no-ref/ eth1_mdio_pa2: eth1_mdio_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa4: eth1_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_pps_out_pa5: eth1_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_clk_pa11: eth1_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pe11: eth1_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_er_pf12: eth1_tx_er_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdc_pg2: eth1_mdc_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_mdio_pg3: eth1_mdio_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_pg12: eth1_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_phy_intn_ph6: eth1_phy_intn_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa4: eth2_pps_out_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_pps_out_pa5: eth2_pps_out_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pa11: eth2_clk_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb2: eth2_mdio_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdio_pb6: eth2_mdio_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_er_pe11: eth2_tx_er_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_mdc_pg5: eth2_mdc_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_clk_pg8: eth2_clk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF13)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg12: eth2_phy_intn_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_phy_intn_pg15: eth2_phy_intn_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {
@@ -2665,6 +2767,340 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* SAI */
+
+			/omit-if-no-ref/ sai1_sd_b_pa0: sai1_sd_b_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pa3: sai1_fs_b_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pa4: sai1_sck_a_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pa4: sai1_sck_b_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pa5: sai1_d1_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pa5: sai1_sd_a_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb2: sai1_d1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pb2: sai1_sd_a_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pb6: sai1_ck2_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pb8: sai1_d1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_pc0: sai1_ck2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_pc0: sai1_sck_a_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc1: sai1_d3_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pc3: sai1_ck1_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pc3: sai1_mclk_a_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pc4: sai1_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pc5: sai1_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd0: sai1_ck1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd0: sai1_mclk_a_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pd3: sai1_d3_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d1_pd6: sai1_d1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pd6: sai1_sd_a_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck1_pd13: sai1_ck1_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_a_pd13: sai1_mclk_a_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_b_pe2: sai1_fs_b_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe4: sai1_d2_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pe6: sai1_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pe11: sai1_d2_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe11: sai1_fs_a_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pe14: sai1_d4_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_b_pf8: sai1_sck_b_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d4_pf9: sai1_d4_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_d3_pf10: sai1_d3_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_d2_pf11: sai1_d2_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pf11: sai1_fs_a_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_a_pf12: sai1_sd_a_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pf13: sai1_mclk_b_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai1_mclk_b_pg8: sai1_mclk_b_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_sd_b_pg10: sai1_sd_b_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai1_ck2_ph12: sai1_ck2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai1_sck_a_ph12: sai1_sck_a_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pa6: sai2_ck2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pa6: sai2_sck_a_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pa7: sai2_d1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pa7: sai2_sd_a_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pa8: sai2_ck1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa8: sai2_mclk_a_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pa12: sai2_mclk_a_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb0: sai2_d2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb0: sai2_fs_a_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pb3: sai2_ck1_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pb3: sai2_mclk_a_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pb4: sai2_ck2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pb4: sai2_sck_a_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pb15: sai2_d2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pb15: sai2_fs_a_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck1_pc2: sai2_ck1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_a_pc2: sai2_mclk_a_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pc4: sai2_d3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pc5: sai2_d4_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_pc8: sai2_fs_b_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pc10: sai2_mclk_b_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pc11: sai2_sck_b_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pc12: sai2_sd_b_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pd2: sai2_d1_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d4_pe3: sai2_d4_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe5: sai2_sck_b_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_b_pe6: sai2_sck_b_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d2_pg1: sai2_d2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_a_pg1: sai2_fs_a_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_mclk_b_pg2: sai2_mclk_b_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_b_pg3: sai2_sd_b_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg6: sai2_d1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg6: sai2_sd_a_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_pg11: sai2_d3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_ck2_pg12: sai2_ck2_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sck_a_pg12: sai2_sck_a_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF4)>;
+			};
+
+			/omit-if-no-ref/ sai2_d1_pg14: sai2_d1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF6)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_pg14: sai2_sd_a_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF10)>;
+			};
+
+			/omit-if-no-ref/ sai2_fs_b_ph7: sai2_fs_b_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ sai2_d3_ph10: sai2_d3_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF3)>;
+			};
+
+			/omit-if-no-ref/ sai2_sd_a_ph11: sai2_sd_a_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF3)>;
+			};
+
 			/* SDMMC */
 
 			/omit-if-no-ref/ sdmmc1_d123dir_pb3: sdmmc1_d123dir_pb3 {
@@ -3595,139 +4031,116 @@
 			/omit-if-no-ref/ usart1_cts_pa7: usart1_cts_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart1_cts_pa11: usart1_cts_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pc5: usart2_cts_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe11: usart2_cts_pe11 {
 				pinmux = <STM32_PINMUX('E', 11, AF2)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart2_cts_pe15: usart2_cts_pe15 {
 				pinmux = <STM32_PINMUX('E', 15, AF3)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc7: usart3_cts_pc7 {
 				pinmux = <STM32_PINMUX('C', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pc8: usart3_cts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
 				pinmux = <STM32_PINMUX('D', 11, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_pg12: usart3_cts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart3_cts_ph10: usart3_cts_ph10 {
 				pinmux = <STM32_PINMUX('H', 10, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pb0: uart4_cts_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart4_cts_pf7: uart4_cts_pf7 {
 				pinmux = <STM32_PINMUX('F', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc3: uart5_cts_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart5_cts_pc9: uart5_cts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg13: usart6_cts_pg13 {
 				pinmux = <STM32_PINMUX('G', 13, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ usart6_cts_pg15: usart6_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pb15: uart7_cts_pb15 {
 				pinmux = <STM32_PINMUX('B', 15, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pf9: uart7_cts_pf9 {
 				pinmux = <STM32_PINMUX('F', 9, AF7)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg7: uart7_cts_pg7 {
 				pinmux = <STM32_PINMUX('G', 7, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart7_cts_pg15: uart7_cts_pg15 {
 				pinmux = <STM32_PINMUX('G', 15, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pd14: uart8_cts_pd14 {
 				pinmux = <STM32_PINMUX('D', 14, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/omit-if-no-ref/ uart8_cts_pg10: uart8_cts_pg10 {
 				pinmux = <STM32_PINMUX('G', 10, AF8)>;
 				bias-pull-up;
-				drive-open-drain;
 			};
 
 			/* UART_DE / USART_DE / LPUART_DE */
@@ -3836,128 +4249,107 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart1_rts_pc2: usart1_rts_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF3)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pc9: usart3_rts_pc9 {
 				pinmux = <STM32_PINMUX('C', 9, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
 				pinmux = <STM32_PINMUX('D', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pe3: usart3_rts_pe3 {
 				pinmux = <STM32_PINMUX('E', 3, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart3_rts_pg8: usart3_rts_pg8 {
 				pinmux = <STM32_PINMUX('G', 8, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa6: uart4_rts_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pa15: uart4_rts_pa15 {
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart4_rts_pe6: uart4_rts_pe6 {
 				pinmux = <STM32_PINMUX('E', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc4: uart5_rts_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart5_rts_pc8: uart5_rts_pc8 {
 				pinmux = <STM32_PINMUX('C', 8, AF11)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pe2: usart6_rts_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pf10: usart6_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ usart6_rts_pg12: usart6_rts_pg12 {
 				pinmux = <STM32_PINMUX('G', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pb12: uart7_rts_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pe4: uart7_rts_pe4 {
 				pinmux = <STM32_PINMUX('E', 4, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart7_rts_pf10: uart7_rts_pf10 {
 				pinmux = <STM32_PINMUX('F', 10, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe12: uart8_rts_pe12 {
 				pinmux = <STM32_PINMUX('E', 12, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/omit-if-no-ref/ uart8_rts_pe14: uart8_rts_pe14 {
 				pinmux = <STM32_PINMUX('E', 14, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
+				drive-push-pull;
 			};
 
 			/* UART_RX / USART_RX / LPUART_RX */

--- a/dts/st/n6/stm32n645a0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645a0hxq-pinctrl.dtsi
@@ -943,7 +943,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_mdc_pd1: eth1_mdc_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;

--- a/dts/st/n6/stm32n645b0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645b0hxq-pinctrl.dtsi
@@ -1251,7 +1251,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_mdc_pd1: eth1_mdc_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;

--- a/dts/st/n6/stm32n645i0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645i0hxq-pinctrl.dtsi
@@ -1141,7 +1141,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_mdc_pd1: eth1_mdc_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;

--- a/dts/st/n6/stm32n645l0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645l0hxq-pinctrl.dtsi
@@ -1373,7 +1373,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_mdc_pd1: eth1_mdc_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;

--- a/dts/st/n6/stm32n645x0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645x0hxq-pinctrl.dtsi
@@ -1517,7 +1517,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_mdc_pd1: eth1_mdc_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;

--- a/dts/st/n6/stm32n647a0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647a0hxq-pinctrl.dtsi
@@ -943,7 +943,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_mdc_pd1: eth1_mdc_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;

--- a/dts/st/n6/stm32n647b0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647b0hxq-pinctrl.dtsi
@@ -1251,7 +1251,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_mdc_pd1: eth1_mdc_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;

--- a/dts/st/n6/stm32n647i0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647i0hxq-pinctrl.dtsi
@@ -1141,7 +1141,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_mdc_pd1: eth1_mdc_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;

--- a/dts/st/n6/stm32n647l0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647l0hxq-pinctrl.dtsi
@@ -1373,7 +1373,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_mdc_pd1: eth1_mdc_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;

--- a/dts/st/n6/stm32n647x0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647x0hxq-pinctrl.dtsi
@@ -1517,7 +1517,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_mdc_pd1: eth1_mdc_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;

--- a/dts/st/n6/stm32n655a0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655a0hxq-pinctrl.dtsi
@@ -943,7 +943,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_mdc_pd1: eth1_mdc_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;

--- a/dts/st/n6/stm32n655b0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655b0hxq-pinctrl.dtsi
@@ -1251,7 +1251,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_mdc_pd1: eth1_mdc_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;

--- a/dts/st/n6/stm32n655i0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655i0hxq-pinctrl.dtsi
@@ -1141,7 +1141,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_mdc_pd1: eth1_mdc_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;

--- a/dts/st/n6/stm32n655l0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655l0hxq-pinctrl.dtsi
@@ -1373,7 +1373,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_mdc_pd1: eth1_mdc_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;

--- a/dts/st/n6/stm32n655x0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655x0hxq-pinctrl.dtsi
@@ -1517,7 +1517,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_mdc_pd1: eth1_mdc_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;

--- a/dts/st/n6/stm32n657a0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657a0hxq-pinctrl.dtsi
@@ -943,7 +943,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_mdc_pd1: eth1_mdc_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;

--- a/dts/st/n6/stm32n657b0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657b0hxq-pinctrl.dtsi
@@ -1251,7 +1251,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_mdc_pd1: eth1_mdc_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;

--- a/dts/st/n6/stm32n657i0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657i0hxq-pinctrl.dtsi
@@ -1141,7 +1141,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_mdc_pd1: eth1_mdc_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;

--- a/dts/st/n6/stm32n657l0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657l0hxq-pinctrl.dtsi
@@ -1373,7 +1373,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_mdc_pd1: eth1_mdc_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;

--- a/dts/st/n6/stm32n657x0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657x0hxq-pinctrl.dtsi
@@ -1517,7 +1517,7 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH (STM32N6 IP) */
+			/* ETH (Extended) */
 
 			/omit-if-no-ref/ eth1_mdc_pd1: eth1_mdc_pd1 {
 				pinmux = <STM32_PINMUX('D', 1, AF11)>;

--- a/dts/st/u5/stm32u599bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599bjyxq-pinctrl.dtsi
@@ -1456,6 +1456,103 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HSPI */
+
+			/omit-if-no-ref/ hspi1_ncs_ph9: hspi1_ncs_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io0_ph10: hspi1_io0_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io1_ph11: hspi1_io1_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io2_ph12: hspi1_io2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io3_ph13: hspi1_io3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io4_ph14: hspi1_io4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io5_ph15: hspi1_io5_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io6_pi0: hspi1_io6_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io7_pi1: hspi1_io7_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_nclk_pi4: hspi1_nclk_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io8_pi9: hspi1_io8_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io9_pi10: hspi1_io9_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io10_pi11: hspi1_io10_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io11_pi12: hspi1_io11_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io12_pi13: hspi1_io12_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io13_pi14: hspi1_io13_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io14_pi15: hspi1_io14_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io15_pj0: hspi1_io15_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/u5/stm32u599nihxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599nihxq-pinctrl.dtsi
@@ -1500,6 +1500,103 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HSPI */
+
+			/omit-if-no-ref/ hspi1_ncs_ph9: hspi1_ncs_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io0_ph10: hspi1_io0_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io1_ph11: hspi1_io1_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io2_ph12: hspi1_io2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io3_ph13: hspi1_io3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io4_ph14: hspi1_io4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io5_ph15: hspi1_io5_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io6_pi0: hspi1_io6_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io7_pi1: hspi1_io7_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_nclk_pi4: hspi1_nclk_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io8_pi9: hspi1_io8_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io9_pi10: hspi1_io9_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io10_pi11: hspi1_io10_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io11_pi12: hspi1_io11_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io12_pi13: hspi1_io12_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io13_pi14: hspi1_io13_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io14_pi15: hspi1_io14_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io15_pj0: hspi1_io15_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/u5/stm32u599njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599njhxq-pinctrl.dtsi
@@ -1500,6 +1500,103 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HSPI */
+
+			/omit-if-no-ref/ hspi1_ncs_ph9: hspi1_ncs_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io0_ph10: hspi1_io0_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io1_ph11: hspi1_io1_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io2_ph12: hspi1_io2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io3_ph13: hspi1_io3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io4_ph14: hspi1_io4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io5_ph15: hspi1_io5_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io6_pi0: hspi1_io6_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io7_pi1: hspi1_io7_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_nclk_pi4: hspi1_nclk_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io8_pi9: hspi1_io8_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io9_pi10: hspi1_io9_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io10_pi11: hspi1_io10_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io11_pi12: hspi1_io11_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io12_pi13: hspi1_io12_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io13_pi14: hspi1_io13_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io14_pi15: hspi1_io14_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io15_pj0: hspi1_io15_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/u5/stm32u5a9bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9bjyxq-pinctrl.dtsi
@@ -1456,6 +1456,103 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HSPI */
+
+			/omit-if-no-ref/ hspi1_ncs_ph9: hspi1_ncs_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io0_ph10: hspi1_io0_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io1_ph11: hspi1_io1_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io2_ph12: hspi1_io2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io3_ph13: hspi1_io3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io4_ph14: hspi1_io4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io5_ph15: hspi1_io5_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io6_pi0: hspi1_io6_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io7_pi1: hspi1_io7_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_nclk_pi4: hspi1_nclk_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io8_pi9: hspi1_io8_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io9_pi10: hspi1_io9_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io10_pi11: hspi1_io10_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io11_pi12: hspi1_io11_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io12_pi13: hspi1_io12_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io13_pi14: hspi1_io13_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io14_pi15: hspi1_io14_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io15_pj0: hspi1_io15_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/u5/stm32u5a9njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9njhxq-pinctrl.dtsi
@@ -1500,6 +1500,103 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HSPI */
+
+			/omit-if-no-ref/ hspi1_ncs_ph9: hspi1_ncs_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io0_ph10: hspi1_io0_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io1_ph11: hspi1_io1_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io2_ph12: hspi1_io2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io3_ph13: hspi1_io3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io4_ph14: hspi1_io4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io5_ph15: hspi1_io5_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io6_pi0: hspi1_io6_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io7_pi1: hspi1_io7_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_nclk_pi4: hspi1_nclk_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io8_pi9: hspi1_io8_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io9_pi10: hspi1_io9_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io10_pi11: hspi1_io10_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io11_pi12: hspi1_io11_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io12_pi13: hspi1_io12_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io13_pi14: hspi1_io13_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io14_pi15: hspi1_io14_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io15_pj0: hspi1_io15_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/u5/stm32u5f9bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9bjyxq-pinctrl.dtsi
@@ -1418,6 +1418,103 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HSPI */
+
+			/omit-if-no-ref/ hspi1_ncs_ph9: hspi1_ncs_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io0_ph10: hspi1_io0_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io1_ph11: hspi1_io1_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io2_ph12: hspi1_io2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io3_ph13: hspi1_io3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io4_ph14: hspi1_io4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io5_ph15: hspi1_io5_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io6_pi0: hspi1_io6_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io7_pi1: hspi1_io7_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_nclk_pi4: hspi1_nclk_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io8_pi9: hspi1_io8_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io9_pi10: hspi1_io9_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io10_pi11: hspi1_io10_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io11_pi12: hspi1_io11_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io12_pi13: hspi1_io12_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io13_pi14: hspi1_io13_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io14_pi15: hspi1_io14_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io15_pj0: hspi1_io15_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/u5/stm32u5f9njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9njhxq-pinctrl.dtsi
@@ -1462,6 +1462,103 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HSPI */
+
+			/omit-if-no-ref/ hspi1_ncs_ph9: hspi1_ncs_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io0_ph10: hspi1_io0_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io1_ph11: hspi1_io1_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io2_ph12: hspi1_io2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io3_ph13: hspi1_io3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io4_ph14: hspi1_io4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io5_ph15: hspi1_io5_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io6_pi0: hspi1_io6_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io7_pi1: hspi1_io7_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_nclk_pi4: hspi1_nclk_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io8_pi9: hspi1_io8_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io9_pi10: hspi1_io9_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io10_pi11: hspi1_io10_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io11_pi12: hspi1_io11_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io12_pi13: hspi1_io12_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io13_pi14: hspi1_io13_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io14_pi15: hspi1_io14_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io15_pj0: hspi1_io15_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/u5/stm32u5f9vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9vitxq-pinctrl.dtsi
@@ -642,6 +642,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HSPI */
+
+			/omit-if-no-ref/ hspi1_ncs_ph9: hspi1_ncs_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io0_ph10: hspi1_io0_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io1_ph11: hspi1_io1_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io2_ph12: hspi1_io2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io3_ph13: hspi1_io3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io4_ph14: hspi1_io4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io5_ph15: hspi1_io5_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io6_pi0: hspi1_io6_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io7_pi1: hspi1_io7_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/u5/stm32u5f9vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9vjtxq-pinctrl.dtsi
@@ -642,6 +642,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HSPI */
+
+			/omit-if-no-ref/ hspi1_ncs_ph9: hspi1_ncs_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io0_ph10: hspi1_io0_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io1_ph11: hspi1_io1_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io2_ph12: hspi1_io2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io3_ph13: hspi1_io3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io4_ph14: hspi1_io4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io5_ph15: hspi1_io5_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io6_pi0: hspi1_io6_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io7_pi1: hspi1_io7_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/u5/stm32u5f9zijxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zijxq-pinctrl.dtsi
@@ -1072,6 +1072,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HSPI */
+
+			/omit-if-no-ref/ hspi1_ncs_ph9: hspi1_ncs_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io0_ph10: hspi1_io0_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io1_ph11: hspi1_io1_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io2_ph12: hspi1_io2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io3_ph13: hspi1_io3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io4_ph14: hspi1_io4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io5_ph15: hspi1_io5_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io6_pi0: hspi1_io6_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io7_pi1: hspi1_io7_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/u5/stm32u5f9zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zitxq-pinctrl.dtsi
@@ -1072,6 +1072,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HSPI */
+
+			/omit-if-no-ref/ hspi1_ncs_ph9: hspi1_ncs_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io0_ph10: hspi1_io0_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io1_ph11: hspi1_io1_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io2_ph12: hspi1_io2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io3_ph13: hspi1_io3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io4_ph14: hspi1_io4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io5_ph15: hspi1_io5_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io6_pi0: hspi1_io6_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io7_pi1: hspi1_io7_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/u5/stm32u5f9zjjxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zjjxq-pinctrl.dtsi
@@ -1072,6 +1072,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HSPI */
+
+			/omit-if-no-ref/ hspi1_ncs_ph9: hspi1_ncs_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io0_ph10: hspi1_io0_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io1_ph11: hspi1_io1_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io2_ph12: hspi1_io2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io3_ph13: hspi1_io3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io4_ph14: hspi1_io4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io5_ph15: hspi1_io5_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io6_pi0: hspi1_io6_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io7_pi1: hspi1_io7_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/u5/stm32u5f9zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zjtxq-pinctrl.dtsi
@@ -1072,6 +1072,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HSPI */
+
+			/omit-if-no-ref/ hspi1_ncs_ph9: hspi1_ncs_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io0_ph10: hspi1_io0_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io1_ph11: hspi1_io1_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io2_ph12: hspi1_io2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io3_ph13: hspi1_io3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io4_ph14: hspi1_io4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io5_ph15: hspi1_io5_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io6_pi0: hspi1_io6_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io7_pi1: hspi1_io7_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/u5/stm32u5g9bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9bjyxq-pinctrl.dtsi
@@ -1418,6 +1418,103 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HSPI */
+
+			/omit-if-no-ref/ hspi1_ncs_ph9: hspi1_ncs_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io0_ph10: hspi1_io0_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io1_ph11: hspi1_io1_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io2_ph12: hspi1_io2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io3_ph13: hspi1_io3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io4_ph14: hspi1_io4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io5_ph15: hspi1_io5_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io6_pi0: hspi1_io6_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io7_pi1: hspi1_io7_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_nclk_pi4: hspi1_nclk_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io8_pi9: hspi1_io8_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io9_pi10: hspi1_io9_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io10_pi11: hspi1_io10_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io11_pi12: hspi1_io11_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io12_pi13: hspi1_io12_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io13_pi14: hspi1_io13_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io14_pi15: hspi1_io14_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io15_pj0: hspi1_io15_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/u5/stm32u5g9njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9njhxq-pinctrl.dtsi
@@ -1506,6 +1506,103 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HSPI */
+
+			/omit-if-no-ref/ hspi1_ncs_ph9: hspi1_ncs_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io0_ph10: hspi1_io0_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io1_ph11: hspi1_io1_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io2_ph12: hspi1_io2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io3_ph13: hspi1_io3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io4_ph14: hspi1_io4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io5_ph15: hspi1_io5_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io6_pi0: hspi1_io6_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io7_pi1: hspi1_io7_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_nclk_pi4: hspi1_nclk_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io8_pi9: hspi1_io8_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io9_pi10: hspi1_io9_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io10_pi11: hspi1_io10_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io11_pi12: hspi1_io11_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io12_pi13: hspi1_io12_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io13_pi14: hspi1_io13_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io14_pi15: hspi1_io14_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io15_pj0: hspi1_io15_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/u5/stm32u5g9vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9vjtxq-pinctrl.dtsi
@@ -678,6 +678,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HSPI */
+
+			/omit-if-no-ref/ hspi1_ncs_ph9: hspi1_ncs_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io0_ph10: hspi1_io0_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io1_ph11: hspi1_io1_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io2_ph12: hspi1_io2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io3_ph13: hspi1_io3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io4_ph14: hspi1_io4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io5_ph15: hspi1_io5_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io6_pi0: hspi1_io6_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io7_pi1: hspi1_io7_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/u5/stm32u5g9zjjxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9zjjxq-pinctrl.dtsi
@@ -1108,6 +1108,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HSPI */
+
+			/omit-if-no-ref/ hspi1_ncs_ph9: hspi1_ncs_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io0_ph10: hspi1_io0_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io1_ph11: hspi1_io1_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io2_ph12: hspi1_io2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io3_ph13: hspi1_io3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io4_ph14: hspi1_io4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io5_ph15: hspi1_io5_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io6_pi0: hspi1_io6_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io7_pi1: hspi1_io7_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/u5/stm32u5g9zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9zjtxq-pinctrl.dtsi
@@ -1108,6 +1108,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HSPI */
+
+			/omit-if-no-ref/ hspi1_ncs_ph9: hspi1_ncs_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io0_ph10: hspi1_io0_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io1_ph11: hspi1_io1_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io2_ph12: hspi1_io2_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io3_ph13: hspi1_io3_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io4_ph14: hspi1_io4_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io5_ph15: hspi1_io5_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io6_pi0: hspi1_io6_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_io7_pi1: hspi1_io7_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -111,6 +111,10 @@
 - name: HRTIM_SCIN / HRTIM_SCOUT
   match: "^HRTIM\\d+_SC(IN|OUT)$"
 
+- name: HSPI
+  match: "^HSPI(.*)(?:CLK|NCS|DQS|IO\\d+)$"
+  slew-rate: very-high-speed
+
 - name: I2C_SCL
   match: "^I2C\\d+_SCL$"
   drive: open-drain

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -72,7 +72,7 @@
   match: "^ETH+_(?:COL$|CRS|CRS_DV|MDC|MDIO|PPS_OUT|REF_CLK|RX_CLK|RX_DV|RX_ER||RXD[0-3]|TX_CLK|TX_EN|TXD[0-3])$"
   slew-rate: very-high-speed
 
-- name: ETH (STM32N6 IP)
+- name: ETH (Extended)
   match: "^ETH\\d+_(?:MDC|MDIO|PHY_INTN|PPS_OUT|CLK|TX_ER)$"
   slew-rate: very-high-speed
 
@@ -211,7 +211,7 @@
 
 - name: TSC
   match: "^TSC_(?:G\\d+_IO\\d+|SYNC)$"
-  
+
 - name: UART_CTS / USART_CTS / LPUART_CTS
   match: "^(?:LP)?US?ART\\d+_CTS$"
   bias: pull-up
@@ -247,4 +247,3 @@
 
 - name: USB
   match: "^USB_(?:DM)?(?:DP)?(?:NOE)?$"
-


### PR DESCRIPTION
- Rename ETH N6 IP label to be less confusing when generated on other series.
- Generate ETH extended signals on STM32MP13
- Generate HSPI signals (STM32U5)