### PR TITLE
lib/stm32: stm32wba: radio temperature calibration activation

### DIFF
--- a/lib/stm32wba/BLE_TransparentMode/Core/Inc/app_conf.h
+++ b/lib/stm32wba/BLE_TransparentMode/Core/Inc/app_conf.h
@@ -376,7 +376,11 @@ typedef enum
  * HW RADIO configuration
  ******************************************************************************/
 /* Link Layer uses temperature based calibration (0 --> NO ; 1 --> YES) */
-#define USE_TEMPERATURE_BASED_RADIO_CALIBRATION  (0)
+#ifdef CONFIG_BT_STM32WBA_USE_TEMPERATURE_BASED_RADIO_CALIBRATION
+  #define USE_TEMPERATURE_BASED_RADIO_CALIBRATION  (1)
+#else
+  #define USE_TEMPERATURE_BASED_RADIO_CALIBRATION  (0)
+#endif /*CONFIG_BT_STM32_USE_TEMPERATURE_BASED_RADIO_CALIBRATION*/
 
 #define RADIO_INTR_NUM                      RADIO_IRQn     /* 2.4GHz RADIO global interrupt */
 #define RADIO_INTR_PRIO_HIGH                (0)            /* 2.4GHz RADIO interrupt priority when radio is Active */

--- a/lib/stm32wba/BLE_TransparentMode/STM32_WPAN/Target/linklayer_plat.c
+++ b/lib/stm32wba/BLE_TransparentMode/STM32_WPAN/Target/linklayer_plat.c
@@ -28,10 +28,10 @@
 #include "linklayer_plat.h"
 #include "scm.h"
 #include "log_module.h"
+#ifndef __ZEPHYR__
 #if (USE_TEMPERATURE_BASED_RADIO_CALIBRATION == 1)
 #include "adc_ctrl.h"
 #endif /* (USE_TEMPERATURE_BASED_RADIO_CALIBRATION == 1) */
-#ifndef __ZEPHYR__
 #if (CFG_LPM_LEVEL != 0)
 #include "stm32_lpm.h"
 #include "stm32_lpm_if.h"
@@ -502,6 +502,7 @@ void LINKLAYER_PLAT_RCOStopClbr(void)
   while (LL_PWR_IsActiveFlag_VOS() == 0);
 #endif /* (CFG_SCM_SUPPORTED == 1) */
 }
+#endif /*__ZEPHYR__*/
 
 /**
   * @brief  Link Layer requests temperature.
@@ -514,7 +515,7 @@ void LINKLAYER_PLAT_RequestTemperature(void)
   ll_sys_bg_temperature_measurement();
 #endif /* USE_TEMPERATURE_BASED_RADIO_CALIBRATION */
 }
-
+#ifndef __ZEPHYR__
 /**
   * @brief  Enable RTOS context switch.
   * @param  None

--- a/lib/stm32wba/BLE_TransparentMode/STM32_WPAN/Target/ll_sys_if.c
+++ b/lib/stm32wba/BLE_TransparentMode/STM32_WPAN/Target/ll_sys_if.c
@@ -23,10 +23,11 @@
 #include "ll_sys.h"
 #include "ll_sys_if.h"
 #include "utilities_common.h"
+#ifndef __ZEPHYR__
 #if (USE_TEMPERATURE_BASED_RADIO_CALIBRATION == 1)
 #include "temp_measurement.h"
 #endif /* (USE_TEMPERATURE_BASED_RADIO_CALIBRATION == 1) */
-
+#endif /*__ZEPHYR__*/
 /* Private defines -----------------------------------------------------------*/
 /* Radio event scheduling method - must be set at 1 */
 #define USE_RADIO_LOW_ISR                   (1)
@@ -58,9 +59,6 @@
 /* USER CODE END GV */
 
 /* Private functions prototypes-----------------------------------------------*/
-#if (USE_TEMPERATURE_BASED_RADIO_CALIBRATION == 1)
-static void ll_sys_bg_temperature_measurement_init(void);
-#endif /* USE_TEMPERATURE_BASED_RADIO_CALIBRATION */
 static void ll_sys_sleep_clock_source_selection(void);
 static uint8_t ll_sys_BLE_sleep_clock_accuracy_selection(void);
 void ll_sys_reset(void);
@@ -129,7 +127,6 @@ void ll_sys_config_params(void)
   /* Apply the selected link layer sleep timer source */
   ll_sys_sleep_clock_source_selection();
 
-#ifndef __ZEPHYR__
 /* USER CODE BEGIN ll_sys_config_params_1 */
 
 /* USER CODE END ll_sys_config_params_1 */
@@ -142,9 +139,10 @@ void ll_sys_config_params(void)
   ll_intf_cmn_set_temperature_sensor_state();
 #endif /* USE_TEMPERATURE_BASED_RADIO_CALIBRATION */
 
+#ifndef __ZEPHYR__
   /* Link Layer power table */
   ll_intf_cmn_select_tx_power_table(CFG_RF_TX_POWER_TABLE_ID);
-#endif 
+#endif  /*__ZEPHYR__*/
 /* USER CODE BEGIN ll_sys_config_params_2 */
 
 /* USER CODE END ll_sys_config_params_2 */

--- a/lib/stm32wba/STM32_WPAN/link_layer/ll_sys/inc/ll_sys.h
+++ b/lib/stm32wba/STM32_WPAN/link_layer/ll_sys/inc/ll_sys.h
@@ -19,6 +19,7 @@
 #ifndef LL_SYS_H
 #define LL_SYS_H
 
+#include "app_conf.h"
 #include "ll_intf.h"
 #include "hci.h"
 #include "cmsis_compiler.h" 
@@ -98,6 +99,12 @@ ll_sys_status_t ll_sys_dp_slp_enter(uint32_t dp_slp_duration);
 ll_sys_status_t ll_sys_dp_slp_exit(void);
 ll_sys_dp_slp_state_t ll_sys_dp_slp_get_state(void);
 void ll_sys_dp_slp_wakeup_evt_clbk(void const *ptr_arg);
+
+/* Link Layer system interface temperature calibration functions  ************************************************/
+#if (USE_TEMPERATURE_BASED_RADIO_CALIBRATION == 1)
+void ll_sys_bg_temperature_measurement_init(void);
+void ll_sys_bg_temperature_measurement(void);
+#endif /* USE_TEMPERATURE_BASED_RADIO_CALIBRATION */
 
 /**
   * @brief  Get the number of concurrent state machines for the Link Layer


### PR DESCRIPTION
This work on the lib/stm32 allows to activate/deactivate the calibration of the radio based on the temperature sensor.
It can be activated/deactivated by a Zephyr config