### PR TITLE
dts: Generate dqs0 and dqs1 signals

### DIFF
--- a/dts/st/u5/stm32u599bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599bjyxq-pinctrl.dtsi
@@ -1503,6 +1503,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ hspi1_dqs0_pi2: hspi1_dqs0_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
 				pinmux = <STM32_PINMUX('I', 3, AF8)>;
 				slew-rate = "very-high-speed";
@@ -1510,6 +1515,11 @@
 
 			/omit-if-no-ref/ hspi1_nclk_pi4: hspi1_nclk_pi4 {
 				pinmux = <STM32_PINMUX('I', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_dqs1_pi8: hspi1_dqs1_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/u5/stm32u599nihxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599nihxq-pinctrl.dtsi
@@ -1547,6 +1547,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ hspi1_dqs0_pi2: hspi1_dqs0_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
 				pinmux = <STM32_PINMUX('I', 3, AF8)>;
 				slew-rate = "very-high-speed";
@@ -1554,6 +1559,11 @@
 
 			/omit-if-no-ref/ hspi1_nclk_pi4: hspi1_nclk_pi4 {
 				pinmux = <STM32_PINMUX('I', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_dqs1_pi8: hspi1_dqs1_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/u5/stm32u599njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599njhxq-pinctrl.dtsi
@@ -1547,6 +1547,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ hspi1_dqs0_pi2: hspi1_dqs0_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
 				pinmux = <STM32_PINMUX('I', 3, AF8)>;
 				slew-rate = "very-high-speed";
@@ -1554,6 +1559,11 @@
 
 			/omit-if-no-ref/ hspi1_nclk_pi4: hspi1_nclk_pi4 {
 				pinmux = <STM32_PINMUX('I', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_dqs1_pi8: hspi1_dqs1_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/u5/stm32u5a9bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9bjyxq-pinctrl.dtsi
@@ -1503,6 +1503,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ hspi1_dqs0_pi2: hspi1_dqs0_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
 				pinmux = <STM32_PINMUX('I', 3, AF8)>;
 				slew-rate = "very-high-speed";
@@ -1510,6 +1515,11 @@
 
 			/omit-if-no-ref/ hspi1_nclk_pi4: hspi1_nclk_pi4 {
 				pinmux = <STM32_PINMUX('I', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_dqs1_pi8: hspi1_dqs1_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/u5/stm32u5a9njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9njhxq-pinctrl.dtsi
@@ -1547,6 +1547,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ hspi1_dqs0_pi2: hspi1_dqs0_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
 				pinmux = <STM32_PINMUX('I', 3, AF8)>;
 				slew-rate = "very-high-speed";
@@ -1554,6 +1559,11 @@
 
 			/omit-if-no-ref/ hspi1_nclk_pi4: hspi1_nclk_pi4 {
 				pinmux = <STM32_PINMUX('I', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_dqs1_pi8: hspi1_dqs1_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/u5/stm32u5f9bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9bjyxq-pinctrl.dtsi
@@ -1465,6 +1465,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ hspi1_dqs0_pi2: hspi1_dqs0_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
 				pinmux = <STM32_PINMUX('I', 3, AF8)>;
 				slew-rate = "very-high-speed";
@@ -1472,6 +1477,11 @@
 
 			/omit-if-no-ref/ hspi1_nclk_pi4: hspi1_nclk_pi4 {
 				pinmux = <STM32_PINMUX('I', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_dqs1_pi8: hspi1_dqs1_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/u5/stm32u5f9njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9njhxq-pinctrl.dtsi
@@ -1509,6 +1509,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ hspi1_dqs0_pi2: hspi1_dqs0_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
 				pinmux = <STM32_PINMUX('I', 3, AF8)>;
 				slew-rate = "very-high-speed";
@@ -1516,6 +1521,11 @@
 
 			/omit-if-no-ref/ hspi1_nclk_pi4: hspi1_nclk_pi4 {
 				pinmux = <STM32_PINMUX('I', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_dqs1_pi8: hspi1_dqs1_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/u5/stm32u5f9vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9vitxq-pinctrl.dtsi
@@ -689,6 +689,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ hspi1_dqs0_pi2: hspi1_dqs0_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
 				pinmux = <STM32_PINMUX('I', 3, AF8)>;
 				slew-rate = "very-high-speed";

--- a/dts/st/u5/stm32u5f9vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9vjtxq-pinctrl.dtsi
@@ -689,6 +689,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ hspi1_dqs0_pi2: hspi1_dqs0_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
 				pinmux = <STM32_PINMUX('I', 3, AF8)>;
 				slew-rate = "very-high-speed";

--- a/dts/st/u5/stm32u5f9zijxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zijxq-pinctrl.dtsi
@@ -1119,6 +1119,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ hspi1_dqs0_pi2: hspi1_dqs0_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
 				pinmux = <STM32_PINMUX('I', 3, AF8)>;
 				slew-rate = "very-high-speed";

--- a/dts/st/u5/stm32u5f9zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zitxq-pinctrl.dtsi
@@ -1119,6 +1119,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ hspi1_dqs0_pi2: hspi1_dqs0_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
 				pinmux = <STM32_PINMUX('I', 3, AF8)>;
 				slew-rate = "very-high-speed";

--- a/dts/st/u5/stm32u5f9zjjxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zjjxq-pinctrl.dtsi
@@ -1119,6 +1119,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ hspi1_dqs0_pi2: hspi1_dqs0_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
 				pinmux = <STM32_PINMUX('I', 3, AF8)>;
 				slew-rate = "very-high-speed";

--- a/dts/st/u5/stm32u5f9zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zjtxq-pinctrl.dtsi
@@ -1119,6 +1119,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ hspi1_dqs0_pi2: hspi1_dqs0_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
 				pinmux = <STM32_PINMUX('I', 3, AF8)>;
 				slew-rate = "very-high-speed";

--- a/dts/st/u5/stm32u5g9bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9bjyxq-pinctrl.dtsi
@@ -1465,6 +1465,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ hspi1_dqs0_pi2: hspi1_dqs0_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
 				pinmux = <STM32_PINMUX('I', 3, AF8)>;
 				slew-rate = "very-high-speed";
@@ -1472,6 +1477,11 @@
 
 			/omit-if-no-ref/ hspi1_nclk_pi4: hspi1_nclk_pi4 {
 				pinmux = <STM32_PINMUX('I', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_dqs1_pi8: hspi1_dqs1_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/u5/stm32u5g9njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9njhxq-pinctrl.dtsi
@@ -1553,6 +1553,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ hspi1_dqs0_pi2: hspi1_dqs0_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
 				pinmux = <STM32_PINMUX('I', 3, AF8)>;
 				slew-rate = "very-high-speed";
@@ -1560,6 +1565,11 @@
 
 			/omit-if-no-ref/ hspi1_nclk_pi4: hspi1_nclk_pi4 {
 				pinmux = <STM32_PINMUX('I', 4, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ hspi1_dqs1_pi8: hspi1_dqs1_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, AF8)>;
 				slew-rate = "very-high-speed";
 			};
 

--- a/dts/st/u5/stm32u5g9vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9vjtxq-pinctrl.dtsi
@@ -725,6 +725,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ hspi1_dqs0_pi2: hspi1_dqs0_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
 				pinmux = <STM32_PINMUX('I', 3, AF8)>;
 				slew-rate = "very-high-speed";

--- a/dts/st/u5/stm32u5g9zjjxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9zjjxq-pinctrl.dtsi
@@ -1155,6 +1155,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ hspi1_dqs0_pi2: hspi1_dqs0_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
 				pinmux = <STM32_PINMUX('I', 3, AF8)>;
 				slew-rate = "very-high-speed";

--- a/dts/st/u5/stm32u5g9zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9zjtxq-pinctrl.dtsi
@@ -1155,6 +1155,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ hspi1_dqs0_pi2: hspi1_dqs0_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF8)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ hspi1_clk_pi3: hspi1_clk_pi3 {
 				pinmux = <STM32_PINMUX('I', 3, AF8)>;
 				slew-rate = "very-high-speed";

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -112,7 +112,7 @@
   match: "^HRTIM\\d+_SC(IN|OUT)$"
 
 - name: HSPI
-  match: "^HSPI(.*)(?:CLK|NCS|DQS|IO\\d+)$"
+  match: "^HSPI(.*)(?:CLK|NCS|DQS[0-1]|IO\\d+)$"
   slew-rate: very-high-speed
 
 - name: I2C_SCL


### PR DESCRIPTION
For HSPI DQS pins could be numbered 0 or 1. Take it into account in the pinctrl-config script and generate a new batch of -pinctrl.dtsi files