### PR TITLE
STM32MP2: fix the USE_HAL_DRIVER include

### DIFF
--- a/stm32cube/stm32mp2xx/README
+++ b/stm32cube/stm32mp2xx/README
@@ -53,4 +53,10 @@ Patch List:
 	 assertion checks are not implemented, as the code still functions
 	 correctly without them.
 
+   * Fix the USE_HAL_DRIVER included header
+   - The stm32cube/stm32mp2xx/soc/stm32mp2xx.h file
+	 was modified to include the correct header for the HAL driver.
+	 "stm32mp2xx_hal_conf.h" -> "stm32mp2xx_hal.h"
+	 This change ensures that the HAL driver is properly included in the build.
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32mp2xx/soc/stm32mp2xx.h
+++ b/stm32cube/stm32mp2xx/soc/stm32mp2xx.h
@@ -384,7 +384,7 @@ typedef enum
   */
 
 #if defined (USE_HAL_DRIVER)
- #include "stm32mp2xx_hal_conf.h"
+ #include "stm32mp2xx_hal.h"
 #endif /* USE_HAL_DRIVER */
 
 #ifdef __cplusplus


### PR DESCRIPTION
Modify the included HAL header in stm32mp2xx.h to the correct one. "stm32mp2xx_hal_conf.h" -> "stm32mp2xx_hal.h"

"stm32mp2xx_hal.h" was never included in build time and caused declaration errors when using the HAL driver.

This was discovered when trying to update the hwinfo driver to pass CI_tests for [STM32MP2 integration in Zephyr](https://github.com/zephyrproject-rtos/zephyr/pull/90295#) which requires hal functions. 