### PR TITLE
fix: scripts: mp1 series eth pin config

### DIFF
--- a/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
@@ -1504,6 +1504,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
@@ -1392,6 +1392,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
@@ -1504,6 +1504,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
@@ -1392,6 +1392,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
@@ -1504,6 +1504,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
@@ -1392,6 +1392,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
@@ -1504,6 +1504,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
@@ -1392,6 +1392,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_nl_pb7: fmc_nl_pb7 {

--- a/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
@@ -1504,6 +1504,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
@@ -1392,6 +1392,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
@@ -1504,6 +1504,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
@@ -1392,6 +1392,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
@@ -1504,6 +1504,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
@@ -1392,6 +1392,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
@@ -1504,6 +1504,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
@@ -1392,6 +1392,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
@@ -1504,6 +1504,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
@@ -1392,6 +1392,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
@@ -1504,6 +1504,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
@@ -1392,6 +1392,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
@@ -1504,6 +1504,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
@@ -1392,6 +1392,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
@@ -1504,6 +1504,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
@@ -1392,6 +1392,158 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pg4: eth1_gtx_clk_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_ph6: eth1_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_ph7: eth1_rxd3_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi10: eth1_rx_er_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
@@ -1052,6 +1052,128 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pb8: eth1_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pb10: eth1_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pb12: eth1_txd0_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pb13: eth1_txd1_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe2: eth1_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pg11: eth1_tx_ctl_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pg11: eth1_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/mp13/stm32mp131aaex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131aaex-pinctrl.dtsi
@@ -820,6 +820,153 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp13/stm32mp131aafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131aafx-pinctrl.dtsi
@@ -820,6 +820,153 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp13/stm32mp131aagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131aagx-pinctrl.dtsi
@@ -820,6 +820,153 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp13/stm32mp131caex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131caex-pinctrl.dtsi
@@ -820,6 +820,153 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp13/stm32mp131cafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131cafx-pinctrl.dtsi
@@ -820,6 +820,153 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp13/stm32mp131cagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131cagx-pinctrl.dtsi
@@ -820,6 +820,153 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp13/stm32mp131daex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131daex-pinctrl.dtsi
@@ -820,6 +820,153 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp13/stm32mp131dafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131dafx-pinctrl.dtsi
@@ -820,6 +820,153 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp13/stm32mp131dagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131dagx-pinctrl.dtsi
@@ -820,6 +820,153 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp13/stm32mp131faex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131faex-pinctrl.dtsi
@@ -820,6 +820,153 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp13/stm32mp131fafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131fafx-pinctrl.dtsi
@@ -820,6 +820,153 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp13/stm32mp131fagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131fagx-pinctrl.dtsi
@@ -820,6 +820,153 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FMC */
 
 			/omit-if-no-ref/ fmc_a21_pa8: fmc_a21_pa8 {

--- a/dts/st/mp13/stm32mp133aaex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133aaex-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp133aafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133aafx-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp133aagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133aagx-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp133caex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133caex-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp133cafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133cafx-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp133cagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133cagx-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp133daex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133daex-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp133dafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133dafx-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp133dagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133dagx-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp133faex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133faex-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp133fafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133fafx-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp133fagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133fagx-pinctrl.dtsi
@@ -978,6 +978,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp135aaex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135aaex-pinctrl.dtsi
@@ -1265,6 +1265,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp135aafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135aafx-pinctrl.dtsi
@@ -1265,6 +1265,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp135aagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135aagx-pinctrl.dtsi
@@ -1265,6 +1265,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp135caex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135caex-pinctrl.dtsi
@@ -1265,6 +1265,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp135cafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135cafx-pinctrl.dtsi
@@ -1265,6 +1265,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp135cagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135cagx-pinctrl.dtsi
@@ -1265,6 +1265,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp135daex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135daex-pinctrl.dtsi
@@ -1265,6 +1265,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp135dafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135dafx-pinctrl.dtsi
@@ -1265,6 +1265,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp135dagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135dagx-pinctrl.dtsi
@@ -1265,6 +1265,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp135faex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135faex-pinctrl.dtsi
@@ -1265,6 +1265,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp135fafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135fafx-pinctrl.dtsi
@@ -1265,6 +1265,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/dts/st/mp13/stm32mp135fagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135fagx-pinctrl.dtsi
@@ -1265,6 +1265,288 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_STM32MP1 */
+
+			/omit-if-no-ref/ eth1_crs_pa0: eth1_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pa1: eth1_ref_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pa1: eth1_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_pa3: eth1_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pa7: eth1_crs_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_ctl_pa7: eth1_rx_ctl_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pa7: eth1_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd2_pb0: eth1_rxd2_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd3_pb1: eth1_rxd3_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_ctl_pb11: eth1_tx_ctl_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_en_pb11: eth1_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_dv_pc1: eth1_crs_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_gtx_clk_pc1: eth1_gtx_clk_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_dv_pc1: eth1_rx_dv_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd2_pc2: eth1_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_pc3: eth1_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd0_pc4: eth1_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rxd1_pc5: eth1_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_ref_clk_pd7: eth1_ref_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_clk_pd7: eth1_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd3_pe5: eth1_txd3_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd0_pg13: eth1_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_txd1_pg14: eth1_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph2: eth1_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_col_ph3: eth1_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_ph6: eth1_rx_er_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_tx_clk_ph7: eth1_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_crs_ph12: eth1_crs_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth1_rx_er_pi3: eth1_rx_er_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_pa0: eth2_crs_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_pa3: eth2_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd3_pa8: eth2_rxd3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pa11: eth2_rxd1_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pa12: eth2_crs_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pa12: eth2_rx_ctl_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pa12: eth2_rx_dv_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_pc3: eth2_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd1_pe2: eth2_rxd1_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd3_pe6: eth2_txd3_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd0_pf4: eth2_rxd0_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_ctl_pf6: eth2_tx_ctl_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_en_pf6: eth2_tx_en_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd0_pf7: eth2_txd0_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_er_pf11: eth2_rx_er_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd2_pg1: eth2_txd2_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_gtx_clk_pg3: eth2_gtx_clk_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_txd1_pg11: eth2_txd1_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_dv_pg12: eth2_crs_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_ctl_pg12: eth2_rx_ctl_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_dv_pg12: eth2_rx_dv_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_crs_ph2: eth2_crs_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_col_ph3: eth2_col_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rxd2_ph6: eth2_rxd2_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_tx_clk_ph7: eth2_tx_clk_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_ref_clk_ph11: eth2_ref_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth2_rx_clk_ph11: eth2_rx_clk_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pd0: fdcan1_rx_pd0 {

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -86,6 +86,10 @@
   match: '^ETH\d?_MII_(?:COL|CRS|RXD[0-3]|RX_CLK|RX_DV|RX_ER|TX_EN|TXD[0-3]|TX_CLK|TX_EN)$'
   slew-rate: very-high-speed
 
+- name: ETH_STM32MP1
+  match: "^ETH[12]_(COL|CRS|CRS_DV|GTX_CLK|REF_CLK|RX_CLK|RX_CTL|RX_DV|RX_ER|RXD[0-3]|TX_CLK|TX_CTL|TX_EN|TXD[0-3])$"
+  slew-rate: very-high-speed
+
 - name: ETH_RGMII
   match: "^ETH\\d+_RGMII_(?:CLK125|GTX_CLK|RXD[0-3]|RX_CLK|RX_CTL|RX_ER|TX_EN|RX_DV|TXD[0-3]|TX_CTL)$"
   slew-rate: very-high-speed


### PR DESCRIPTION
STM32MP1 series has different Ethernet namings than what is specified in stm32-pinctrl-config.yaml, so I did put another config file with one regex; `ETH[12]_(CLK|COL|CRS|CRS_DV|GTX_CLK|MDC|MDIO|PHY_INTN|PPS_OUT|REF_CLK|RX_CLK|RX_CTL|RX_DV|RX_ER|RXD|TX_CLK|TX_CTL|TX_EN|TX_ER|TXD)`