### PR TITLE
lib: stm32wba: use reference count for backup domain accesses

### DIFF
--- a/lib/stm32wba/BLE_TransparentMode/STM32_WPAN/Target/linklayer_plat.c
+++ b/lib/stm32wba/BLE_TransparentMode/STM32_WPAN/Target/linklayer_plat.c
@@ -70,12 +70,20 @@ void LINKLAYER_PLAT_ClockInit(void)
 	AHB5_SwitchedOff = 0;
 	radio_sleep_timer_val = 0;
 
+#ifdef __ZEPHYR__
+	LINKLAYER_PLAT_EnableBackupDomainAccess();
+#else
 	LL_PWR_EnableBkUpAccess();
+#endif
 
 	/* Select LSE as Sleep CLK */
 	__HAL_RCC_RADIOSLPTIM_CONFIG(RCC_RADIOSTCLKSOURCE_LSE);
 
+#ifdef __ZEPHYR__
+	LINKLAYER_PLAT_DisableBackupDomainAccess();
+#else
 	LL_PWR_DisableBkUpAccess();
+#endif
 
 	/* Enable AHB5ENR peripheral clock (bus CLK) */
 	__HAL_RCC_RADIO_CLK_ENABLE();

--- a/lib/stm32wba/STM32_WPAN/link_layer/ll_sys/inc/linklayer_plat.h
+++ b/lib/stm32wba/STM32_WPAN/link_layer/ll_sys/inc/linklayer_plat.h
@@ -29,6 +29,22 @@
   */
 extern void LINKLAYER_PLAT_ClockInit(void);
 
+#ifdef __ZEPHYR__
+/**
+ * @brief  Enable access to backup domain resources
+ * @param  None
+ * @retval None
+ */
+extern void LINKLAYER_PLAT_EnableBackupDomainAccess(void);
+
+/**
+ * @brief  Disable access to backup domain resources
+ * @param  None
+ * @retval None
+ */
+extern void LINKLAYER_PLAT_DisableBackupDomainAccess(void);
+#endif /* __ZEPHYR__ */
+
 /**
   * @brief  Link Layer active waiting loop.
   * @param  delay: delay in us


### PR DESCRIPTION
Use Zephyr function `stm32_backup_domain_enable_access()` and `stm32_backup_domain_disable_access()` to enable/disable access to LSE configuration registers under back domain access protection instead of raw access. These functions have a reference counter for access requests to ensure access remains enabled when other component require it.