### PR TITLE
stm32mp2xx_ll_rcc: add support for I2C8 clock configuration

### DIFF
--- a/stm32cube/stm32mp2xx/README
+++ b/stm32cube/stm32mp2xx/README
@@ -59,4 +59,8 @@ Patch List:
 	 "stm32mp2xx_hal_conf.h" -> "stm32mp2xx_hal.h"
 	 This change ensures that the HAL driver is properly included in the build.
 
+   * Add support for I2C8 clock configuration
+   - The stm32cube/stm32mp2xx/drivers/src/stm32mp2xx_ll_rcc.c file was modified
+    for retrieving the clock configuration of the I2C8 peripheral.
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32mp2xx/drivers/src/stm32mp2xx_ll_rcc.c
+++ b/stm32cube/stm32mp2xx/drivers/src/stm32mp2xx_ll_rcc.c
@@ -779,6 +779,14 @@ uint32_t LL_RCC_GetI2CClockFreq(uint32_t I2CxSource)
       break;
 #endif /* LL_RCC_I2C3_CLKSOURCE */
 
+#if defined(LL_RCC_I2C8_CLKSOURCE)
+    case LL_RCC_I2C8_CLKSOURCE:
+      i2c_source = LL_RCC_GetI2C8ClockSource();
+      i2c_prediv = LL_RCC_GetI2C8_PREDIV();
+      i2c_findiv = LL_RCC_GetI2C8_FINDIV();
+      break;
+#endif /* LL_RCC_I2C8_CLKSOURCE */
+
 #if defined(LL_RCC_I3C4_CLKSOURCE)
     case LL_RCC_I3C4_CLKSOURCE:
       i2c_source = LL_RCC_GetI3C4ClockSource();


### PR DESCRIPTION
This PR adds support for retrieving the I2C8 device clock configuration in the HAL RCC driver. This will be used by the Zephyr clock driver to read the I2C8 clock frequency in the same way as I2C1-7.