### PR TITLE
dts: st: u3: stm32u385rgtxq:  add missing sa1_fs_a pins

### DIFF
--- a/dts/README.rst
+++ b/dts/README.rst
@@ -43,4 +43,10 @@ License Link:
    https://www.apache.org/licenses/LICENSE-2.0
 
 Patch List:
-   None
+   *Missing additional pins for SAI1_FS_A and SAI1_FS_B signals on STM32U3 serie
+      - Add the SAI1_FS_A signal name on PB9 and PE4 in the appropriate U3 pinctrl file.
+      - Add the SAI1_FS_B signal name on PE9 in the appropriate U3 pinctrl files.
+      -Link: https://github.com/STMicroelectronics/STM32_open_pin_data/issues/15
+      - Impacted files:
+         dts/st/u3/stm32u375*-pinctrl.dtsi
+         dts/st/u3/stm32u385*-pinctrl.dtsi

--- a/dts/st/u3/stm32u385rgtxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u385rgtxq-pinctrl.dtsi
@@ -786,6 +786,14 @@
 				pinmux = <STM32_PINMUX('A', 9, AF13)>;
 			};
 
+			/omit-if-no-ref/ sai1_fs_a_pb9: sai1_fs_a_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/omit-if-no-ref/ sai1_fs_a_pe4: sai1_fs_a_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF13)>;
+			};
+
 			/omit-if-no-ref/ sai1_d1_pa10: sai1_d1_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF3)>;
 			};


### PR DESCRIPTION
This PR adds some missing SAI1 signals.

We observed that the STM32U385RGTxQ.xml file (https://github.com/STMicroelectronics/STM32_open_pin_data/blob/master/mcu/STM32U385RGTxQ.xml) contains only one pin definition. However, the Nucleo U385RG Q datasheet (https://www.st.com/resource/en/datasheet/stm32u385cg.pdf, page 85) shows additional signals available on AF13.

Currently, there is not enough time to investigate other U3_*.xml files or create an issue in the STM32_open_pin_data repository.

These changes are required to resolve issues encountered in the I2S sample ( https://github.com/zephyrproject-rtos/zephyr/pull/94082)