### PR TITLE
dcmipp: allow PIPE_SetConfig when pipe state is READY

### DIFF
--- a/stm32cube/stm32h7rsxx/README
+++ b/stm32cube/stm32h7rsxx/README
@@ -61,4 +61,13 @@ Patch List:
      Impacted file: 
       stm32cube/stm32h7rsxx/drivers/src/stm32h7rsxx_hal_sdio.c    
 
+   *Allow usage of HAL_DCMIPP_PIPE_SetConfig when DCMIPP is in READY state
+     Allow performing PIPE configuration when the DCMIPP device is not only
+     in RESET and ERROR states but also in READY state. This allow to
+     reconfigure a DCMIPP pipe between 2 use-cases without having to
+     call HAL_DCMIPP_DeInit / HAL_DCMIPP_Init.
+     Impacted file:
+      stm32cube/stm32h7rsxx/drivers/src/stm32h7rsxx_hal_dcmipp.c
+     Internal reference: 215688
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32h7rsxx/drivers/src/stm32h7rsxx_hal_dcmipp.c
+++ b/stm32cube/stm32h7rsxx/drivers/src/stm32h7rsxx_hal_dcmipp.c
@@ -490,7 +490,8 @@ HAL_StatusTypeDef HAL_DCMIPP_PIPE_SetConfig(DCMIPP_HandleTypeDef *hdcmipp, uint3
 
   if (hdcmipp->State == HAL_DCMIPP_STATE_READY)
   {
-    if ((pipe_state == HAL_DCMIPP_PIPE_STATE_RESET) || (pipe_state == HAL_DCMIPP_PIPE_STATE_ERROR))
+    if ((pipe_state == HAL_DCMIPP_PIPE_STATE_READY) || (pipe_state == HAL_DCMIPP_PIPE_STATE_RESET) ||
+        (pipe_state == HAL_DCMIPP_PIPE_STATE_ERROR))
     {
       /* Update the DCMIPP PIPE state */
       hdcmipp->PipeState[Pipe] = HAL_DCMIPP_PIPE_STATE_BUSY;

--- a/stm32cube/stm32mp13xx/README
+++ b/stm32cube/stm32mp13xx/README
@@ -47,4 +47,13 @@ Patch List:
     Impacted files:
      drivers/include/Legacy/stm32_hal_legacy.h
 
+   *Allow usage of HAL_DCMIPP_PIPE_SetConfig when DCMIPP is in READY state
+     Allow performing PIPE configuration when the DCMIPP device is not only
+     in RESET and ERROR states but also in READY state. This allow to
+     reconfigure a DCMIPP pipe between 2 use-cases without having to
+     call HAL_DCMIPP_DeInit / HAL_DCMIPP_Init.
+     Impacted file:
+      stm32cube/stm32mp13xx/drivers/src/stm32mp13xx_hal_dcmipp.c
+     Internal reference: 215688
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32mp13xx/drivers/src/stm32mp13xx_hal_dcmipp.c
+++ b/stm32cube/stm32mp13xx/drivers/src/stm32mp13xx_hal_dcmipp.c
@@ -484,7 +484,8 @@ HAL_StatusTypeDef HAL_DCMIPP_PIPE_Config(DCMIPP_HandleTypeDef *phdcmipp, uint32_
 
   if (phdcmipp->State == HAL_DCMIPP_STATE_READY)
   {
-    if ((pipe_state == HAL_DCMIPP_PIPE_STATE_RESET) || \
+    if ((pipe_state == HAL_DCMIPP_PIPE_STATE_READY) ||
+	(pipe_state == HAL_DCMIPP_PIPE_STATE_RESET) ||
         (pipe_state == HAL_DCMIPP_PIPE_STATE_ERROR))
     {
       /* Update the DCMIPP PIPE state */

--- a/stm32cube/stm32mp2xx/README
+++ b/stm32cube/stm32mp2xx/README
@@ -63,4 +63,13 @@ Patch List:
    - The stm32cube/stm32mp2xx/drivers/src/stm32mp2xx_ll_rcc.c file was modified
     for retrieving the clock configuration of the I2C8 peripheral.
 
+   *Allow usage of HAL_DCMIPP_PIPE_SetConfig when DCMIPP is in READY state
+     Allow performing PIPE configuration when the DCMIPP device is not only
+     in RESET and ERROR states but also in READY state. This allow to
+     reconfigure a DCMIPP pipe between 2 use-cases without having to
+     call HAL_DCMIPP_DeInit / HAL_DCMIPP_Init.
+     Impacted file:
+      stm32cube/stm32mp2xx/drivers/src/stm32mp2xx_hal_dcmipp.c
+     Internal reference: 215688
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32mp2xx/drivers/src/stm32mp2xx_hal_dcmipp.c
+++ b/stm32cube/stm32mp2xx/drivers/src/stm32mp2xx_hal_dcmipp.c
@@ -1414,7 +1414,8 @@ HAL_StatusTypeDef HAL_DCMIPP_PIPE_SetConfig(DCMIPP_HandleTypeDef *hdcmipp, uint3
 
   if (hdcmipp->State == HAL_DCMIPP_STATE_READY)
   {
-    if ((pipe_state == HAL_DCMIPP_PIPE_STATE_RESET) || (pipe_state == HAL_DCMIPP_PIPE_STATE_ERROR))
+    if ((pipe_state == HAL_DCMIPP_PIPE_STATE_READY) || (pipe_state == HAL_DCMIPP_PIPE_STATE_RESET) ||
+        (pipe_state == HAL_DCMIPP_PIPE_STATE_ERROR))
     {
       /* Update the DCMIPP PIPE state */
       hdcmipp->PipeState[Pipe] = HAL_DCMIPP_PIPE_STATE_BUSY;

--- a/stm32cube/stm32n6xx/README
+++ b/stm32cube/stm32n6xx/README
@@ -75,4 +75,13 @@ Patch List:
      Impacted file:
       stm32cube/stm32n6xx/drivers/src/stm32n6xx_hal_sdio.c
 
+   *Allow usage of HAL_DCMIPP_PIPE_SetConfig when DCMIPP is in READY state
+     Allow performing PIPE configuration when the DCMIPP device is not only
+     in RESET and ERROR states but also in READY state. This allow to
+     reconfigure a DCMIPP pipe between 2 use-cases without having to
+     call HAL_DCMIPP_DeInit / HAL_DCMIPP_Init.
+     Impacted file:
+      stm32cube/stm32n6xx/drivers/src/stm32n6xx_hal_dcmipp.c
+    Internal reference: 215688
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32n6xx/drivers/src/stm32n6xx_hal_dcmipp.c
+++ b/stm32cube/stm32n6xx/drivers/src/stm32n6xx_hal_dcmipp.c
@@ -1041,7 +1041,8 @@ HAL_StatusTypeDef HAL_DCMIPP_PIPE_SetConfig(DCMIPP_HandleTypeDef *hdcmipp, uint3
 
   if (hdcmipp->State == HAL_DCMIPP_STATE_READY)
   {
-    if ((pipe_state == HAL_DCMIPP_PIPE_STATE_RESET) || (pipe_state == HAL_DCMIPP_PIPE_STATE_ERROR))
+    if ((pipe_state == HAL_DCMIPP_PIPE_STATE_READY) || (pipe_state == HAL_DCMIPP_PIPE_STATE_RESET) ||
+        (pipe_state == HAL_DCMIPP_PIPE_STATE_ERROR))
     {
       /* Update the DCMIPP PIPE state */
       hdcmipp->PipeState[Pipe] = HAL_DCMIPP_PIPE_STATE_BUSY;


### PR DESCRIPTION
Allow to call HAL_DCMIPP_PIPE_SetConfig when the pipe state is READY. Currently it is only possible to use this function if the pipe state is RESET and ERROR states.
Indeed, it is possible to reconfigure the PIPE as soon as the pipe is not currently being used, aka in the READY state. With that done, it becomes possible to change the PIPE configuration between two use-cases without having to DeInit / Init the HAL_DCMIPP or use the unitary pixel packer functions.