### PR TITLE
hal_stm32: dts:  h7/r/s :  add missing eth_mii and eth_rmii signals 

### DIFF
--- a/dts/st/h7/stm32h7r3a8ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3a8ix-pinctrl.dtsi
@@ -907,6 +907,145 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pd8: eth_mii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd2_pf5: eth_mii_rxd2_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pd8: eth_rmii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7r3i8kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3i8kx-pinctrl.dtsi
@@ -968,6 +968,150 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pd8: eth_mii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_crs_pf3: eth_mii_crs_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd2_pf5: eth_mii_rxd2_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pd8: eth_rmii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7r3i8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3i8tx-pinctrl.dtsi
@@ -939,6 +939,150 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pd8: eth_mii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_crs_pf3: eth_mii_crs_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd2_pf5: eth_mii_rxd2_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pd8: eth_rmii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7r3l8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3l8hx-pinctrl.dtsi
@@ -1146,6 +1146,210 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pd8: eth_mii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_crs_pf3: eth_mii_crs_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd2_pf5: eth_mii_rxd2_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pg4: eth_mii_rxd0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pg5: eth_mii_rxd1_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pg11: eth_mii_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pg12: eth_mii_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pg13: eth_mii_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pg14: eth_mii_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pd8: eth_rmii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pg4: eth_rmii_rxd0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pg5: eth_rmii_rxd1_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pg11: eth_rmii_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pg12: eth_rmii_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd0_pg13: eth_rmii_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pg14: eth_rmii_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7r3l8hxh-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3l8hxh-pinctrl.dtsi
@@ -1098,6 +1098,180 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_crs_pf3: eth_mii_crs_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd2_pf5: eth_mii_rxd2_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pg11: eth_mii_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pg12: eth_mii_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pg13: eth_mii_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pg14: eth_mii_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pg11: eth_rmii_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pg12: eth_rmii_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd0_pg13: eth_rmii_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pg14: eth_rmii_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7r3z8jx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3z8jx-pinctrl.dtsi
@@ -785,6 +785,140 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pd8: eth_mii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pd8: eth_rmii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7r3z8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3z8tx-pinctrl.dtsi
@@ -811,6 +811,140 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pd8: eth_mii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pd8: eth_rmii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7r7a8ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7a8ix-pinctrl.dtsi
@@ -881,6 +881,140 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pd8: eth_mii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pd8: eth_rmii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7r7i8kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7i8kx-pinctrl.dtsi
@@ -948,6 +948,150 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pd8: eth_mii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_crs_pf3: eth_mii_crs_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd2_pf5: eth_mii_rxd2_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pd8: eth_rmii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7r7i8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7i8tx-pinctrl.dtsi
@@ -905,6 +905,140 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_crs_pf3: eth_mii_crs_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd2_pf5: eth_mii_rxd2_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7r7l8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7l8hx-pinctrl.dtsi
@@ -1146,6 +1146,210 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pd8: eth_mii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_crs_pf3: eth_mii_crs_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd2_pf5: eth_mii_rxd2_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pg4: eth_mii_rxd0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pg5: eth_mii_rxd1_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pg11: eth_mii_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pg12: eth_mii_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pg13: eth_mii_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pg14: eth_mii_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pd8: eth_rmii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pg4: eth_rmii_rxd0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pg5: eth_rmii_rxd1_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pg11: eth_rmii_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pg12: eth_rmii_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd0_pg13: eth_rmii_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pg14: eth_rmii_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7r7l8hxh-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7l8hxh-pinctrl.dtsi
@@ -1098,6 +1098,180 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_crs_pf3: eth_mii_crs_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd2_pf5: eth_mii_rxd2_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pg11: eth_mii_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pg12: eth_mii_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pg13: eth_mii_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pg14: eth_mii_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pg11: eth_rmii_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pg12: eth_rmii_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd0_pg13: eth_rmii_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pg14: eth_rmii_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7r7z8jx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7z8jx-pinctrl.dtsi
@@ -751,6 +751,130 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7s3a8ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3a8ix-pinctrl.dtsi
@@ -907,6 +907,145 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pd8: eth_mii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd2_pf5: eth_mii_rxd2_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pd8: eth_rmii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7s3i8kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3i8kx-pinctrl.dtsi
@@ -968,6 +968,150 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pd8: eth_mii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_crs_pf3: eth_mii_crs_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd2_pf5: eth_mii_rxd2_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pd8: eth_rmii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7s3i8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3i8tx-pinctrl.dtsi
@@ -939,6 +939,150 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pd8: eth_mii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_crs_pf3: eth_mii_crs_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd2_pf5: eth_mii_rxd2_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pd8: eth_rmii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7s3l8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3l8hx-pinctrl.dtsi
@@ -1146,6 +1146,210 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pd8: eth_mii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_crs_pf3: eth_mii_crs_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd2_pf5: eth_mii_rxd2_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pg4: eth_mii_rxd0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pg5: eth_mii_rxd1_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pg11: eth_mii_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pg12: eth_mii_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pg13: eth_mii_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pg14: eth_mii_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pd8: eth_rmii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pg4: eth_rmii_rxd0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pg5: eth_rmii_rxd1_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pg11: eth_rmii_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pg12: eth_rmii_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd0_pg13: eth_rmii_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pg14: eth_rmii_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7s3l8hxh-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3l8hxh-pinctrl.dtsi
@@ -1098,6 +1098,180 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_crs_pf3: eth_mii_crs_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd2_pf5: eth_mii_rxd2_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pg11: eth_mii_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pg12: eth_mii_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pg13: eth_mii_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pg14: eth_mii_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pg11: eth_rmii_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pg12: eth_rmii_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd0_pg13: eth_rmii_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pg14: eth_rmii_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7s3z8jx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3z8jx-pinctrl.dtsi
@@ -785,6 +785,140 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pd8: eth_mii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pd8: eth_rmii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7s3z8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3z8tx-pinctrl.dtsi
@@ -811,6 +811,140 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pd8: eth_mii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pd8: eth_rmii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7s7a8ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7a8ix-pinctrl.dtsi
@@ -881,6 +881,140 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pd8: eth_mii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pd8: eth_rmii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7s7i8kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7i8kx-pinctrl.dtsi
@@ -948,6 +948,150 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pd8: eth_mii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_crs_pf3: eth_mii_crs_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd2_pf5: eth_mii_rxd2_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pd8: eth_rmii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7s7i8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7i8tx-pinctrl.dtsi
@@ -905,6 +905,140 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_crs_pf3: eth_mii_crs_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd2_pf5: eth_mii_rxd2_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7s7l8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7l8hx-pinctrl.dtsi
@@ -1146,6 +1146,210 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pd8: eth_mii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_crs_pf3: eth_mii_crs_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd2_pf5: eth_mii_rxd2_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pg4: eth_mii_rxd0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pg5: eth_mii_rxd1_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pg11: eth_mii_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pg12: eth_mii_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pg13: eth_mii_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pg14: eth_mii_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pd8: eth_rmii_tx_en_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pg4: eth_rmii_rxd0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pg5: eth_rmii_rxd1_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pg11: eth_rmii_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pg12: eth_rmii_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd0_pg13: eth_rmii_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pg14: eth_rmii_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7s7l8hxh-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7l8hxh-pinctrl.dtsi
@@ -1098,6 +1098,180 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_crs_pf3: eth_mii_crs_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd2_pf5: eth_mii_rxd2_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pg11: eth_mii_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pg12: eth_mii_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pg13: eth_mii_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pg14: eth_mii_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pg11: eth_rmii_tx_en_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pg12: eth_rmii_txd1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd0_pg13: eth_rmii_txd0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pg14: eth_rmii_txd1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/dts/st/h7/stm32h7s7z8jx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7z8jx-pinctrl.dtsi
@@ -751,6 +751,130 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_MII */
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pa1: eth_mii_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_col_pa3: eth_mii_col_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_dv_pa7: eth_mii_rx_dv_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd0_pb0: eth_mii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb1: eth_mii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pb6: eth_mii_rx_clk_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd1_pb7: eth_mii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pb8: eth_mii_txd3_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_er_pb10: eth_mii_rx_er_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_en_pb11: eth_mii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pb13: eth_mii_rxd3_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd2_pc2: eth_mii_txd2_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_tx_clk_pc3: eth_mii_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd0_pc4: eth_mii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd1_pc5: eth_mii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rx_clk_pd7: eth_mii_rx_clk_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_txd3_pe2: eth_mii_txd3_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_mii_rxd3_pe3: eth_mii_rxd3_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_RMII */
+
+			/omit-if-no-ref/ eth_rmii_txd0_pb0: eth_rmii_txd0_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb1: eth_rmii_txd1_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_txd1_pb7: eth_rmii_txd1_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_tx_en_pb11: eth_rmii_tx_en_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd0_pc4: eth_rmii_rxd0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rmii_rxd1_pc5: eth_rmii_rxd1_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* FDCAN_RX */
 
 			/omit-if-no-ref/ fdcan1_rx_pa11: fdcan1_rx_pa11 {

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -77,7 +77,7 @@
   slew-rate: very-high-speed
 
 - name: ETH_MII
-  match: "^ETH\\d_MII_(?:COL|CRS|RXD[0-3]|RX_CLK|RX_DV|RX_ER|TX_EN|TXD[0-3]|TX_CLK|TX_EN)$"
+  match: '^ETH\d?_MII_(?:COL|CRS|RXD[0-3]|RX_CLK|RX_DV|RX_ER|TX_EN|TXD[0-3]|TX_CLK|TX_EN)$'
   slew-rate: very-high-speed
 
 - name: ETH_RGMII
@@ -85,7 +85,7 @@
   slew-rate: very-high-speed
 
 - name: ETH_RMII
-  match: "^ETH\\d+_RMII_(?:CRS_DV|REF_CLK|RXD[0-1]|RX_CLK|RX_ER|TX_EN|RX_DV|TXD[0-1]|TX_CLK|TX_EN)$"
+  match: '^ETH\d?_RMII_(?:COL|CRS|RXD[0-3]|RX_CLK|RX_DV|RX_ER|TX_EN|TXD[0-3]|TX_CLK|TX_EN)$'
   slew-rate: very-high-speed
 
 - name: FDCAN_RX


### PR DESCRIPTION
This PR updates the h7r/s-pinctrl.dtsi by adding missing `eth_mii` and `eth_rmii` signals.




fixes issue https://github.com/zephyrproject-rtos/zephyr/issues/94268