### PR TITLE
stm32cube: stm32h7xx: drivers: Correct DMA source and destination addresses

### DIFF
--- a/stm32cube/stm32h7xx/README
+++ b/stm32cube/stm32h7xx/README
@@ -75,4 +75,9 @@ Patch List:
      Impacted file: 
       stm32cube/stm32h7xx/drivers/src/stm32h7xx_hal_sdio.c
          
+   *Fix an issue in the STM32H7 HAL OSPI by correcting the DMA source and destination
+      addresses in the HAL_MDMA_Start_IT() call.
+      Impacted files:
+      stm32cube/stm32h7xx/drivers/src/stm32h7xx_hal_ospi.c
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32h7xx/drivers/src/stm32h7xx_hal_ospi.c
+++ b/stm32cube/stm32h7xx/drivers/src/stm32h7xx_hal_ospi.c
@@ -1495,7 +1495,7 @@ HAL_StatusTypeDef HAL_OSPI_Transmit_DMA(OSPI_HandleTypeDef *hospi, uint8_t *pDat
         }
 
         /* Enable the transmit MDMA Channel */
-        if (HAL_MDMA_Start_IT(hospi->hmdma, (uint32_t)&hospi->Instance->DR, (uint32_t)pData, hospi->XferSize, 1) == \
+        if (HAL_MDMA_Start_IT(hospi->hmdma, (uint32_t)pData, (uint32_t)&hospi->Instance->DR, hospi->XferSize, 1) == \
             HAL_OK)
         {
           /* Enable the transfer error interrupt */


### PR DESCRIPTION
The source and destination addresses in the HAL_MDMA_Start_IT call were swapped, causing incorrect data transfers. The data buffer (pData) should be the source, and the OSPI data register (DR) should be the destination. This commit fixes the argument order to ensure proper data transmission via DMA.

fixes: #94350