### PR TITLE
stm32: dts: st: f1: fix pinmux to use TIM3_REMAP2

### DIFF
--- a/dts/README.rst
+++ b/dts/README.rst
@@ -50,3 +50,8 @@ Patch List:
       - Impacted files:
          dts/st/u3/stm32u375*-pinctrl.dtsi
          dts/st/u3/stm32u385*-pinctrl.dtsi
+
+   *Rename "TIM3_REMAP1" on the pin "PB5" to "TIM3_REMAP2"
+   of the following GPIO-STM32F103xx.xml files.
+      - Impacted files:
+         dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi

--- a/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
@@ -898,8 +898,8 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
-				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pb5: tim3_ch2_remap2_pwm_out_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP2)>;
 			};
 
 			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {


### PR DESCRIPTION
The previous configuration used TIM3_REMAP1 for mapping TIM3_CH2 to PB5, 
which is not supported according to the STM32F103 reference manual. 
This commit updates the pinmux to use TIM3_REMAP2, enabling proper PWM output on PB5.

fixes: [#94213](https://github.com/zephyrproject-rtos/zephyr/issues/94213)
bug created to fix xml file: https://github.com/STMicroelectronics/STM32_open_pin_data/issues/14