### PR TITLE
Made it possible to use the build in hardware support for clause 45 mdio communication

### DIFF
--- a/stm32cube/stm32h7xx/drivers/include/stm32h7xx_hal_eth.h
+++ b/stm32cube/stm32h7xx/drivers/include/stm32h7xx_hal_eth.h
@@ -1767,6 +1767,10 @@ HAL_StatusTypeDef HAL_ETH_WritePHYRegister(const ETH_HandleTypeDef *heth, uint32
                                            uint32_t RegValue);
 HAL_StatusTypeDef HAL_ETH_ReadPHYRegister(ETH_HandleTypeDef *heth, uint32_t PHYAddr, uint32_t PHYReg,
                                           uint32_t *pRegValue);
+HAL_StatusTypeDef HAL_ETH_ReadPHYRegister_c45(ETH_HandleTypeDef *heth, uint32_t PHYAddr, uint8_t PHYMMD,
+                                              uint32_t PHYReg, uint32_t *pRegValue);
+HAL_StatusTypeDef HAL_ETH_WritePHYRegister_c45(ETH_HandleTypeDef *heth, uint32_t PHYAddr, uint8_t PHYMMD,
+                                               uint32_t PHYReg, uint32_t RegValue);
 
 void              HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth);
 void              HAL_ETH_TxCpltCallback(ETH_HandleTypeDef *heth);


### PR DESCRIPTION
I am using the STM32H7 along with Zephyr and a TJA1103 phy. The phy requires Clause 45 support which the STM32H7 has but it is not included in the hal layer and therefore not available in Zephyr.

I've tried opening an issue in the ST repo but it was denied due to no development boards requiring the functionoality. Another customer also got the same response on a PR a while ago.

So now I'm hoping for the next best solution...

[ST PR](https://github.com/STMicroelectronics/stm32h7xx-hal-driver/pull/52)
[ST Issue](https://github.com/STMicroelectronics/stm32h7xx-hal-driver/issues/90)