### PR TITLE
lib: blobs: change url for stm32wba Link Layer libraries

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -58,12 +58,12 @@ blobs:
     type: lib
     version: '1.6.0'
     license-path: zephyr/blobs/stm32wba/lib/license.md
-    url: https://github.com/stm32-hotspot/STM32WBA-Zephyr-custom-binaries/raw/main/lib/WBA6_LinkLayer15_4_Zephyr.a
+    url: https://github.com/stm32-hotspot/STM32WBA-Zephyr-custom-binaries/raw/main/lib/1_6_0/WBA6_LinkLayer15_4_Zephyr.a
     description: "Binary Link Layer library for the STM32WBA6 802.15.4 subsystem"
   - path: stm32wba/lib/WBA6_LinkLayer_Thread_lib_Zephyr.a
     sha256: 2b8c46d3d8afbe99f89fc4e6cf9a155d28ee273ee5a334a53f6b3f6e4718a944
     type: lib
     version: '1.6.0'
     license-path: zephyr/blobs/stm32wba/lib/license.md
-    url: https://github.com/stm32-hotspot/STM32WBA-Zephyr-custom-binaries/raw/main/lib/WBA6_LinkLayer_Thread_lib_Zephyr.a
+    url: https://github.com/stm32-hotspot/STM32WBA-Zephyr-custom-binaries/raw/main/lib/1_6_0/WBA6_LinkLayer_Thread_lib_Zephyr.a
     description: "Binary Link Layer library for the STM32WBA6 Thread subsystem"


### PR DESCRIPTION
This PR is dedicated to update URL address for WBA6_LinkLayer_Thread_lib_Zephyr.a and WBA6_LinkLayer15_4_Zephyr.a libraries