### PR TITLE
hal_stm32: stm32h5: Add XSPI1 compatibility macros

### DIFF
--- a/stm32cube/stm32h5xx/drivers/include/Legacy/stm32_hal_legacy.h
+++ b/stm32cube/stm32h5xx/drivers/include/Legacy/stm32_hal_legacy.h
@@ -4405,6 +4405,25 @@ extern "C" {
   * @}
   */
 
+/** @defgroup HAL_XSPI_Aliased_Defines HAL XSPI Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#if defined(STM32H5)
+/* STM32H5 uses OCTOSPI naming for XSPI peripherals - add compatibility macros */
+#if !defined(XSPI1) && defined(OCTOSPI1)
+#define XSPI1      OCTOSPI1
+#endif /* !XSPI1 && OCTOSPI1 */
+#if !defined(XSPI1_NS) && defined(OCTOSPI1_NS)
+#define XSPI1_NS   OCTOSPI1_NS
+#endif /* !XSPI1_NS && OCTOSPI1_NS */
+#if !defined(XSPI1_S) && defined(OCTOSPI1_S)
+#define XSPI1_S    OCTOSPI1_S
+#endif /* !XSPI1_S && OCTOSPI1_S */
+#endif /* STM32H5 */
+/**
+  * @}
+  */
+
 /** @defgroup HAL_PPP_Aliased_Macros HAL PPP Aliased Macros maintained for legacy purpose
   * @{
   */


### PR DESCRIPTION
**Note:** This PR is part 1 of 2 for fixing issue #99191.

**Related PR:**
- Part 2: https://github.com/zephyrproject-rtos/zephyr/compare/main...Ayushkothari96:zephyr:fix-stm32-xspi-psram-hal-compatibility?expand=1

Fixes zephyrproject-rtos/zephyr#99191

STM32H5 series uses OCTOSPI naming instead of XSPI for the peripheral instances. Add compatibility macros to alias XSPI1 to OCTOSPI1 to maintain driver compatibility across STM32 series.

This resolves compilation errors when using the XSPI PSRAM driver on STM32H573 and other STM32H5 devices.

**Changes:**
- Added XSPI1, XSPI1_NS, XSPI1_S compatibility macros for STM32H5
- Follows existing HAL legacy pattern for backward compatibility