### PR TITLE
ci: bump test matrix to Python 3.12 and newer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
             --cov-report term \
             --cov-report html \
             -vv
-      - name: store coverage report 
+      - name: store coverage report
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.12']
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python


### PR DESCRIPTION
Zephyr now requires Python 3.12 as minimum version (see https://github.com/zephyrproject-rtos/zephyr/pull/104317).

Drop Python 3.10 and 3.11 from test matrix and, while at it, add 3.13 and 3.14 to catch forward compatibility issues early on (though Python 3.12 EOL is [October 2028](https://devguide.python.org/versions/) so we still have lots of time).