### PR TITLE
stm32cube: stm32c5xx: Use Ethernet callbacks

### DIFF
--- a/stm32cube/stm32c5xx/README
+++ b/stm32cube/stm32c5xx/README
@@ -40,4 +40,6 @@ Patch List:
     -dos2unix applied
     -trailing white spaces removed
 
+   *stm32c5xx_hal_conf.h: Enable USE_HAL_ETH_REGISTER_CALLBACKS
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32c5xx/drivers/templates/common/stm32c5xx_hal_conf.h
+++ b/stm32cube/stm32c5xx/drivers/templates/common/stm32c5xx_hal_conf.h
@@ -246,7 +246,7 @@ extern "C" {
   */
 /* ########################## HAL_ETH Config #################################### */
 #define USE_HAL_ETH_MODULE                      1U
-#define USE_HAL_ETH_REGISTER_CALLBACKS          0U
+#define USE_HAL_ETH_REGISTER_CALLBACKS          1U
 #define USE_HAL_ETH_CLK_ENABLE_MODEL            HAL_CLK_ENABLE_NO
 #define USE_HAL_ETH_USER_DATA                   0U
 #define USE_HAL_ETH_GET_LAST_ERRORS             0U


### PR DESCRIPTION
Use Ethernet callbacks in order to implement Ethernet for the STM32C5x series