### PR TITLE
stm32cube: stm32f4, stm32f7: Fix errata workaround

### DIFF
--- a/stm32cube/stm32f4xx/README
+++ b/stm32cube/stm32f4xx/README
@@ -69,4 +69,10 @@ Patch List:
        drivers/src/stm32f7xx_hal_dfsdm.c
      ST Internal Reference: HAL1-27454
 
+   *Fix missing errata workaround after writing RE in ETH->MACCR
+    Impacted files:
+     drivers/src/stm32f4xx_hal_eth.c
+    ST Bug tracker ID: HAL1-27528
+    See also https://github.com/zephyrproject-rtos/hal_stm32/pull/362
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32f4xx/drivers/src/stm32f4xx_hal_eth.c
+++ b/stm32cube/stm32f4xx/drivers/src/stm32f4xx_hal_eth.c
@@ -804,14 +804,14 @@ HAL_StatusTypeDef HAL_ETH_Start_IT(ETH_HandleTypeDef *heth)
     /* Enable the MAC transmission */
     SET_BIT(heth->Instance->MACCR, ETH_MACCR_TE);
 
+    /* Enable the MAC reception */
+    SET_BIT(heth->Instance->MACCR, ETH_MACCR_RE);
+
     /* Wait until the write operation will be taken into account :
     at least four TX_CLK/RX_CLK clock cycles */
     tmpreg1 = (heth->Instance)->MACCR;
     HAL_Delay(ETH_REG_WRITE_DELAY);
     (heth->Instance)->MACCR = tmpreg1;
-
-    /* Enable the MAC reception */
-    SET_BIT(heth->Instance->MACCR, ETH_MACCR_RE);
 
     /* Enable ETH DMA interrupts:
     - Tx complete interrupt

--- a/stm32cube/stm32f4xx/drivers/src/stm32f4xx_hal_eth.c
+++ b/stm32cube/stm32f4xx/drivers/src/stm32f4xx_hal_eth.c
@@ -770,8 +770,6 @@ HAL_StatusTypeDef HAL_ETH_Start(ETH_HandleTypeDef *heth)
   */
 HAL_StatusTypeDef HAL_ETH_Start_IT(ETH_HandleTypeDef *heth)
 {
-  uint32_t tmpreg1;
-
   if (heth->gState == HAL_ETH_STATE_READY)
   {
     heth->gState = HAL_ETH_STATE_BUSY;
@@ -785,33 +783,18 @@ HAL_StatusTypeDef HAL_ETH_Start_IT(ETH_HandleTypeDef *heth)
     /* Build all descriptors */
     ETH_UpdateDescriptor(heth);
 
-    /* Wait until the write operation will be taken into account :
+    /* Enable the DMA transmission and reception */
+    SET_BIT(heth->Instance->DMAOMR, (ETH_DMAOMR_ST | ETH_DMAOMR_SR));
+
+    /* Enable the MAC transmission and reception */
+    SET_BIT(heth->Instance->MACCR, (ETH_MACCR_TE | ETH_MACCR_RE));
+
+    /* Wait until the write operations will be taken into account :
     at least four TX_CLK/RX_CLK clock cycles */
-    tmpreg1 = (heth->Instance)->MACCR;
     HAL_Delay(ETH_REG_WRITE_DELAY);
-    (heth->Instance)->MACCR = tmpreg1;
-
-    /* Enable the DMA transmission */
-    SET_BIT(heth->Instance->DMAOMR, ETH_DMAOMR_ST);
-
-    /* Enable the DMA reception */
-    SET_BIT(heth->Instance->DMAOMR, ETH_DMAOMR_SR);
 
     /* Flush Transmit FIFO */
     ETH_FlushTransmitFIFO(heth);
-
-
-    /* Enable the MAC transmission */
-    SET_BIT(heth->Instance->MACCR, ETH_MACCR_TE);
-
-    /* Enable the MAC reception */
-    SET_BIT(heth->Instance->MACCR, ETH_MACCR_RE);
-
-    /* Wait until the write operation will be taken into account :
-    at least four TX_CLK/RX_CLK clock cycles */
-    tmpreg1 = (heth->Instance)->MACCR;
-    HAL_Delay(ETH_REG_WRITE_DELAY);
-    (heth->Instance)->MACCR = tmpreg1;
 
     /* Enable ETH DMA interrupts:
     - Tx complete interrupt

--- a/stm32cube/stm32f7xx/README
+++ b/stm32cube/stm32f7xx/README
@@ -63,4 +63,10 @@ Patch List:
        drivers/src/stm32f7xx_hal_dfsdm.c
      ST Internal Reference: HAL1-27454
 
+   *Fix missing errata workaround after writing RE in ETH->MACCR
+    Impacted files:
+     drivers/src/stm32f7xx_hal_eth.c
+    ST Bug tracker ID: HAL1-27528
+    See also https://github.com/zephyrproject-rtos/hal_stm32/pull/362
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_eth.c
+++ b/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_eth.c
@@ -804,14 +804,14 @@ HAL_StatusTypeDef HAL_ETH_Start_IT(ETH_HandleTypeDef *heth)
     /* Enable the MAC transmission */
     SET_BIT(heth->Instance->MACCR, ETH_MACCR_TE);
 
+    /* Enable the MAC reception */
+    SET_BIT(heth->Instance->MACCR, ETH_MACCR_RE);
+
     /* Wait until the write operation will be taken into account :
     at least four TX_CLK/RX_CLK clock cycles */
     tmpreg1 = (heth->Instance)->MACCR;
     HAL_Delay(ETH_REG_WRITE_DELAY);
     (heth->Instance)->MACCR = tmpreg1;
-
-    /* Enable the MAC reception */
-    SET_BIT(heth->Instance->MACCR, ETH_MACCR_RE);
 
     /* Enable ETH DMA interrupts:
     - Tx complete interrupt

--- a/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_eth.c
+++ b/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_eth.c
@@ -770,8 +770,6 @@ HAL_StatusTypeDef HAL_ETH_Start(ETH_HandleTypeDef *heth)
   */
 HAL_StatusTypeDef HAL_ETH_Start_IT(ETH_HandleTypeDef *heth)
 {
-  uint32_t tmpreg1;
-
   if (heth->gState == HAL_ETH_STATE_READY)
   {
     heth->gState = HAL_ETH_STATE_BUSY;
@@ -785,33 +783,18 @@ HAL_StatusTypeDef HAL_ETH_Start_IT(ETH_HandleTypeDef *heth)
     /* Build all descriptors */
     ETH_UpdateDescriptor(heth);
 
-    /* Wait until the write operation will be taken into account :
+    /* Enable the DMA transmission and reception */
+    SET_BIT(heth->Instance->DMAOMR, (ETH_DMAOMR_ST | ETH_DMAOMR_SR));
+
+    /* Enable the MAC transmission and reception */
+    SET_BIT(heth->Instance->MACCR, (ETH_MACCR_TE | ETH_MACCR_RE));
+
+    /* Wait until the write operations will be taken into account :
     at least four TX_CLK/RX_CLK clock cycles */
-    tmpreg1 = (heth->Instance)->MACCR;
     HAL_Delay(ETH_REG_WRITE_DELAY);
-    (heth->Instance)->MACCR = tmpreg1;
-
-    /* Enable the DMA transmission */
-    SET_BIT(heth->Instance->DMAOMR, ETH_DMAOMR_ST);
-
-    /* Enable the DMA reception */
-    SET_BIT(heth->Instance->DMAOMR, ETH_DMAOMR_SR);
 
     /* Flush Transmit FIFO */
     ETH_FlushTransmitFIFO(heth);
-
-
-    /* Enable the MAC transmission */
-    SET_BIT(heth->Instance->MACCR, ETH_MACCR_TE);
-
-    /* Enable the MAC reception */
-    SET_BIT(heth->Instance->MACCR, ETH_MACCR_RE);
-
-    /* Wait until the write operation will be taken into account :
-    at least four TX_CLK/RX_CLK clock cycles */
-    tmpreg1 = (heth->Instance)->MACCR;
-    HAL_Delay(ETH_REG_WRITE_DELAY);
-    (heth->Instance)->MACCR = tmpreg1;
 
     /* Enable ETH DMA interrupts:
     - Tx complete interrupt


### PR DESCRIPTION
The errata for STM32F4 says successive writes to MACCR may be ignored, and recommends reading back, waiting and rewriting as a workaround. This workaround has been done correctly for writes to TE, but has mistakenly been removed after enabling RE, which means that receiving sometimes ended up not working. The errata recommends doing multiple writes, then a final wait and rewrite at the end, which seems to work correctly.

Even though this is not mentioned in the F7 errata, the same fix is required there.

Fixes zephyrproject-rtos/zephyr#107024.