### PR TITLE
STM32WBA2: Add Bluetooth LE support

### DIFF
--- a/lib/stm32wba/CMakeLists.txt
+++ b/lib/stm32wba/CMakeLists.txt
@@ -61,11 +61,13 @@ if(CONFIG_BT_STM32WBA)
   target_link_libraries(app PUBLIC stm32wba_ble_lib)
 endif()
 
-# Distinguish STM32WBA6x from STM32WBA5x lines
+# Distinguish between lines of the STM32WBA series
 if(CONFIG_SOC_STM32WBA65XX)
   set(libname_prefix "WBA6_")
 elseif(CONFIG_SOC_STM32WBA55XX OR CONFIG_SOC_STM32WBA52XX)
   set(libname_prefix "WBA5_")
+elseif(CONFIG_SOC_STM32WBA25XX OR CONFIG_SOC_STM32WBA23XX)
+  set(libname_prefix "WBA2_")
 else()
   message(FATAL_ERROR "Unsupported SoC: ${CONFIG_SOC}")
 endif()

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -74,3 +74,17 @@ blobs:
     license-path: zephyr/blobs/stm32wba/lib/license.md
     url: https://github.com/stm32-hotspot/STM32WBA-Zephyr-custom-binaries/raw/7343a38195df8a8fd4d31362a5d1568245d13c96/lib/WBA5_LinkLayer_BLE_Basic_15_4_lib_Zephyr.a
     description: "Binary Link Layer library including BLE Basic features for the STM32WBA5 BLE-802.15.4 Concurrent mode subsystem"
+  - path: stm32wba/lib/WBA2_LinkLayer_BLE_Full_lib.a
+    sha256: 09ec037889d7aa5126b759b2f8baa60c726b5246bf7f7cea6178ceef9cc2a44a
+    type: lib
+    version: '1.9.0'
+    license-path: zephyr/blobs/stm32wba/lib/license.md
+    url: https://github.com/STMicroelectronics/stm32-mw-wpan/raw/v2.9.0/link_layer/ll_cmd_lib/lib/WBA2_LinkLayer_BLE_Full_lib.a
+    description: "Binary Link Layer library including BLE Full features for the STM32WBA2 Bluetooth subsystem"
+  - path: stm32wba/lib/WBA2_LinkLayer_BLE_Basic_lib.a
+    sha256: 4f167278eafe22a55d8b4443d9d1f0813999e3ff66ba48bef5d44dbf080a7a6e
+    type: lib
+    version: '1.9.0'
+    license-path: zephyr/blobs/stm32wba/lib/license.md
+    url: https://github.com/STMicroelectronics/stm32-mw-wpan/raw/v2.9.0/link_layer/ll_cmd_lib/lib/WBA2_LinkLayer_BLE_Basic_lib.a
+    description: "Binary Link Layer library including BLE Basic features for the STM32WBA2 Bluetooth subsystem"


### PR DESCRIPTION
Provide Bluetooth LE support for STM32WBA2.

Add WBA2 basic and full BLE libraries (BLOBS).

Supplementary PR [#108116](https://github.com/zephyrproject-rtos/zephyr/pull/108116)