### PR TITLE
stm32cube: dfsdm: fix HAL_DFSDM_IRQHandler

### DIFF
--- a/stm32cube/stm32f4xx/README
+++ b/stm32cube/stm32f4xx/README
@@ -60,4 +60,13 @@ Patch List:
     Impacted files:
      drivers/include/stm32f4xx_ll_fsmc.h
     ST Internal Reference: 223859
+
+   *Fix HAL_DFSDM_IRQHandler
+      HAL_DFSDM_IRQHandler handles IRQ flags in an if {} else if {} condition.
+      This causes interrupts to be handled once and only the first flag
+      encountered in the condition, while there can be several flags raised.
+     Impacted files:
+       drivers/src/stm32f7xx_hal_dfsdm.c
+     ST Internal Reference: HAL1-27454
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32f4xx/drivers/src/stm32f4xx_hal_dfsdm.c
+++ b/stm32cube/stm32f4xx/drivers/src/stm32f4xx_hal_dfsdm.c
@@ -3334,7 +3334,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
 #endif
   }
   /* Check if overrun occurs during injected conversion */
-  else if(((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_JOVRF) != 0U) && \
+  if(((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_JOVRF) != 0U) && \
           ((hdfsdm_filter->Instance->FLTCR2 & DFSDM_FLTCR2_JOVRIE) != 0U))
   {
     /* Clear injected overrun flag */
@@ -3351,7 +3351,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
 #endif
   }
   /* Check if end of regular conversion */
-  else if(((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_REOCF) != 0U) && \
+  if(((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_REOCF) != 0U) && \
           ((hdfsdm_filter->Instance->FLTCR2 & DFSDM_FLTCR2_REOCIE) != 0U))
   {
     /* Call regular conversion complete callback */
@@ -3374,7 +3374,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
     }
   }
   /* Check if end of injected conversion */
-  else if(((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_JEOCF) != 0U) && \
+  if(((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_JEOCF) != 0U) && \
           ((hdfsdm_filter->Instance->FLTCR2 & DFSDM_FLTCR2_JEOCIE) != 0U))
   {
     /* Call injected conversion complete callback */
@@ -3404,7 +3404,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
     }
   }
   /* Check if analog watchdog occurs */
-  else if(((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_AWDF) != 0U) && \
+  if(((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_AWDF) != 0U) && \
           ((hdfsdm_filter->Instance->FLTCR2 & DFSDM_FLTCR2_AWDIE) != 0U))
   {
     uint32_t reg = 0U;
@@ -3436,7 +3436,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
 #endif
   }
   /* Check if clock absence occurs */
-  else if((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
+  if((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
          ((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_CKABF) != 0U) && \
          ((hdfsdm_filter->Instance->FLTCR2 & DFSDM_FLTCR2_CKABIE) != 0U))
   {
@@ -3470,7 +3470,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
   }
 #if defined (DFSDM2_Channel0)
   /* Check if clock absence occurs */
-  else if((hdfsdm_filter->Instance == DFSDM2_Filter0) && \
+  if((hdfsdm_filter->Instance == DFSDM2_Filter0) && \
          ((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_CKABF) != 0U) && \
          ((hdfsdm_filter->Instance->FLTCR2 & DFSDM_FLTCR2_CKABIE) != 0U))
   {
@@ -3504,7 +3504,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
   }
 #endif /* DFSDM2_Channel0 */
   /* Check if short circuit detection occurs */
-  else if((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
+  if((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
          ((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_SCDF) != 0U) && \
          ((hdfsdm_filter->Instance->FLTCR2 & DFSDM_FLTCR2_SCDIE) != 0U))
   {
@@ -3531,7 +3531,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
   }
 #if defined (DFSDM2_Channel0)
   /* Check if short circuit detection occurs */
-  else if((hdfsdm_filter->Instance == DFSDM2_Filter0) && \
+  if((hdfsdm_filter->Instance == DFSDM2_Filter0) && \
          ((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_SCDF) != 0U) && \
          ((hdfsdm_filter->Instance->FLTCR2 & DFSDM_FLTCR2_SCDIE) != 0U))
   {

--- a/stm32cube/stm32f7xx/README
+++ b/stm32cube/stm32f7xx/README
@@ -55,4 +55,12 @@ Patch List:
     Impacted files:
      drivers/include/Legacy/stm32_hal_legacy.h
 
+   *Fix HAL_DFSDM_IRQHandler
+      HAL_DFSDM_IRQHandler handles IRQ flags in an if {} else if {} condition.
+      This causes interrupts to be handled once and only the first flag
+      encountered in the condition, while there can be several flags raised.
+     Impacted files:
+       drivers/src/stm32f7xx_hal_dfsdm.c
+     ST Internal Reference: HAL1-27454
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_dfsdm.c
+++ b/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_dfsdm.c
@@ -2897,7 +2897,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
 #endif
   }
   /* Check if overrun occurs during injected conversion */
-  else if(((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_JOVRF) != 0) && \
+  if(((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_JOVRF) != 0) && \
           ((hdfsdm_filter->Instance->FLTCR2 & DFSDM_FLTCR2_JOVRIE) != 0))
   {
     /* Clear injected overrun flag */
@@ -2914,7 +2914,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
 #endif
   }
   /* Check if end of regular conversion */
-  else if(((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_REOCF) != 0) && \
+  if(((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_REOCF) != 0) && \
           ((hdfsdm_filter->Instance->FLTCR2 & DFSDM_FLTCR2_REOCIE) != 0))
   {
     /* Call regular conversion complete callback */
@@ -2937,7 +2937,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
     }
   }
   /* Check if end of injected conversion */
-  else if(((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_JEOCF) != 0) && \
+  if(((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_JEOCF) != 0) && \
           ((hdfsdm_filter->Instance->FLTCR2 & DFSDM_FLTCR2_JEOCIE) != 0))
   {
     /* Call injected conversion complete callback */
@@ -2967,7 +2967,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
     }
   }
   /* Check if analog watchdog occurs */
-  else if(((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_AWDF) != 0) && \
+  if(((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_AWDF) != 0) && \
           ((hdfsdm_filter->Instance->FLTCR2 & DFSDM_FLTCR2_AWDIE) != 0))
   {
     uint32_t reg = 0;
@@ -2999,7 +2999,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
 #endif
   }
   /* Check if clock absence occurs */
-  else if((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
+  if((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
          ((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_CKABF) != 0) && \
          ((hdfsdm_filter->Instance->FLTCR2 & DFSDM_FLTCR2_CKABIE) != 0))
   {
@@ -3032,7 +3032,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
     }
   }
   /* Check if short circuit detection occurs */
-  else if((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
+  if((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
          ((hdfsdm_filter->Instance->FLTISR & DFSDM_FLTISR_SCDF) != 0) && \
          ((hdfsdm_filter->Instance->FLTCR2 & DFSDM_FLTCR2_SCDIE) != 0))
   {

--- a/stm32cube/stm32h7xx/README
+++ b/stm32cube/stm32h7xx/README
@@ -80,4 +80,12 @@ Patch List:
       Impacted files:
       stm32cube/stm32h7xx/drivers/src/stm32h7xx_hal_ospi.c
 
+   *Fix HAL_DFSDM_IRQHandler
+      HAL_DFSDM_IRQHandler handles IRQ flags in an if {} else if {} condition.
+      This causes interrupts to be handled once and only the first flag
+      encountered in the condition, while there can be several flags raised.
+     Impacted files:
+       drivers/src/stm32f7xx_hal_dfsdm.c
+     ST Internal Reference: HAL1-27454
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32h7xx/drivers/src/stm32h7xx_hal_dfsdm.c
+++ b/stm32cube/stm32h7xx/drivers/src/stm32h7xx_hal_dfsdm.c
@@ -3129,7 +3129,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
 #endif
   }
   /* Check if overrun occurs during injected conversion */
-  else if(((temp_fltisr & DFSDM_FLTISR_JOVRF) != 0U) && \
+  if(((temp_fltisr & DFSDM_FLTISR_JOVRF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_JOVRIE) != 0U))
   {
     /* Clear injected overrun flag */
@@ -3146,7 +3146,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
 #endif
   }
   /* Check if end of regular conversion */
-  else if(((temp_fltisr & DFSDM_FLTISR_REOCF) != 0U) && \
+  if(((temp_fltisr & DFSDM_FLTISR_REOCF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_REOCIE) != 0U))
   {
     /* Call regular conversion complete callback */
@@ -3169,7 +3169,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
     }
   }
   /* Check if end of injected conversion */
-  else if(((temp_fltisr & DFSDM_FLTISR_JEOCF) != 0U) && \
+  if(((temp_fltisr & DFSDM_FLTISR_JEOCF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_JEOCIE) != 0U))
   {
     /* Call injected conversion complete callback */
@@ -3199,7 +3199,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
     }
   }
   /* Check if analog watchdog occurs */
-  else if(((temp_fltisr & DFSDM_FLTISR_AWDF) != 0U) && \
+  if(((temp_fltisr & DFSDM_FLTISR_AWDF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_AWDIE) != 0U))
   {
     uint32_t reg;
@@ -3231,7 +3231,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
 #endif
   }
   /* Check if clock absence occurs */
-  else if((hdfsdm_filter->Instance == filter0Instance) && \
+  if((hdfsdm_filter->Instance == filter0Instance) && \
            ((temp_fltisr & DFSDM_FLTISR_CKABF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_CKABIE) != 0U))
   {
@@ -3264,7 +3264,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
     }
   }
   /* Check if short circuit detection occurs */
-  else if((hdfsdm_filter->Instance == filter0Instance) && \
+  if((hdfsdm_filter->Instance == filter0Instance) && \
            ((temp_fltisr & DFSDM_FLTISR_SCDF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_SCDIE) != 0U))
   {

--- a/stm32cube/stm32l4xx/README
+++ b/stm32cube/stm32l4xx/README
@@ -48,4 +48,12 @@ Patch List:
     Impacted files:
      drivers/include/Legacy/stm32_hal_legacy.h
 
+   *Fix HAL_DFSDM_IRQHandler
+      HAL_DFSDM_IRQHandler handles IRQ flags in an if {} else if {} condition.
+      This causes interrupts to be handled once and only the first flag
+      encountered in the condition, while there can be several flags raised.
+     Impacted files:
+       drivers/src/stm32f7xx_hal_dfsdm.c
+     ST Internal Reference: HAL1-27454
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32l4xx/drivers/src/stm32l4xx_hal_dfsdm.c
+++ b/stm32cube/stm32l4xx/drivers/src/stm32l4xx_hal_dfsdm.c
@@ -2913,7 +2913,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
 #endif
   }
   /* Check if overrun occurs during injected conversion */
-  else if (((temp_fltisr & DFSDM_FLTISR_JOVRF) != 0U) && \
+  if (((temp_fltisr & DFSDM_FLTISR_JOVRF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_JOVRIE) != 0U))
   {
     /* Clear injected overrun flag */
@@ -2930,7 +2930,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
 #endif
   }
   /* Check if end of regular conversion */
-  else if (((temp_fltisr & DFSDM_FLTISR_REOCF) != 0U) && \
+  if (((temp_fltisr & DFSDM_FLTISR_REOCF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_REOCIE) != 0U))
   {
     /* Call regular conversion complete callback */
@@ -2953,7 +2953,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
     }
   }
   /* Check if end of injected conversion */
-  else if (((temp_fltisr & DFSDM_FLTISR_JEOCF) != 0U) && \
+  if (((temp_fltisr & DFSDM_FLTISR_JEOCF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_JEOCIE) != 0U))
   {
     /* Call injected conversion complete callback */
@@ -2983,7 +2983,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
     }
   }
   /* Check if analog watchdog occurs */
-  else if (((temp_fltisr & DFSDM_FLTISR_AWDF) != 0U) && \
+  if (((temp_fltisr & DFSDM_FLTISR_AWDF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_AWDIE) != 0U))
   {
     uint32_t reg;
@@ -3015,7 +3015,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
 #endif
   }
   /* Check if clock absence occurs */
-  else if ((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
+  if ((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
            ((temp_fltisr & DFSDM_FLTISR_CKABF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_CKABIE) != 0U))
   {
@@ -3048,7 +3048,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
     }
   }
   /* Check if short circuit detection occurs */
-  else if ((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
+  if ((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
            ((temp_fltisr & DFSDM_FLTISR_SCDF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_SCDIE) != 0U))
   {

--- a/stm32cube/stm32l5xx/README
+++ b/stm32cube/stm32l5xx/README
@@ -47,4 +47,12 @@ Patch List:
     Impacted files:
      drivers/include/Legacy/stm32_hal_legacy.h
 
+   *Fix HAL_DFSDM_IRQHandler
+      HAL_DFSDM_IRQHandler handles IRQ flags in an if {} else if {} condition.
+      This causes interrupts to be handled once and only the first flag
+      encountered in the condition, while there can be several flags raised.
+     Impacted files:
+       drivers/src/stm32f7xx_hal_dfsdm.c
+     ST Internal Reference: HAL1-27454
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32l5xx/drivers/src/stm32l5xx_hal_dfsdm.c
+++ b/stm32cube/stm32l5xx/drivers/src/stm32l5xx_hal_dfsdm.c
@@ -2901,7 +2901,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
 #endif
   }
   /* Check if overrun occurs during injected conversion */
-  else if (((temp_fltisr & DFSDM_FLTISR_JOVRF) != 0U) && \
+  if (((temp_fltisr & DFSDM_FLTISR_JOVRF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_JOVRIE) != 0U))
   {
     /* Clear injected overrun flag */
@@ -2918,7 +2918,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
 #endif
   }
   /* Check if end of regular conversion */
-  else if (((temp_fltisr & DFSDM_FLTISR_REOCF) != 0U) && \
+  if (((temp_fltisr & DFSDM_FLTISR_REOCF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_REOCIE) != 0U))
   {
     /* Call regular conversion complete callback */
@@ -2941,7 +2941,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
     }
   }
   /* Check if end of injected conversion */
-  else if (((temp_fltisr & DFSDM_FLTISR_JEOCF) != 0U) && \
+  if (((temp_fltisr & DFSDM_FLTISR_JEOCF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_JEOCIE) != 0U))
   {
     /* Call injected conversion complete callback */
@@ -2971,7 +2971,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
     }
   }
   /* Check if analog watchdog occurs */
-  else if (((temp_fltisr & DFSDM_FLTISR_AWDF) != 0U) && \
+  if (((temp_fltisr & DFSDM_FLTISR_AWDF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_AWDIE) != 0U))
   {
     uint32_t reg;
@@ -3003,7 +3003,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
 #endif
   }
   /* Check if clock absence occurs */
-  else if ((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
+  if ((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
            ((temp_fltisr & DFSDM_FLTISR_CKABF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_CKABIE) != 0U))
   {
@@ -3036,7 +3036,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
     }
   }
   /* Check if short circuit detection occurs */
-  else if ((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
+  if ((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
            ((temp_fltisr & DFSDM_FLTISR_SCDF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_SCDIE) != 0U))
   {

--- a/stm32cube/stm32mp13xx/README
+++ b/stm32cube/stm32mp13xx/README
@@ -65,4 +65,12 @@ Patch List:
       stm32cube/stm32mp13xx/drivers/include/stm32mp13xx_hal_eth.h
      Internal reference: 219972
 
+   *Fix HAL_DFSDM_IRQHandler
+      HAL_DFSDM_IRQHandler handles IRQ flags in an if {} else if {} condition.
+      This causes interrupts to be handled once and only the first flag
+      encountered in the condition, while there can be several flags raised.
+     Impacted files:
+       drivers/src/stm32mp13xx_hal_dfsdm.c
+     ST Internal Reference: HAL1-27454
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32mp13xx/drivers/src/stm32mp13xx_hal_dfsdm.c
+++ b/stm32cube/stm32mp13xx/drivers/src/stm32mp13xx_hal_dfsdm.c
@@ -2893,7 +2893,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
 #endif /* USE_HAL_DFSDM_REGISTER_CALLBACKS */
   }
   /* Check if overrun occurs during injected conversion */
-  else if (((temp_fltisr & DFSDM_FLTISR_JOVRF) != 0U) && \
+  if (((temp_fltisr & DFSDM_FLTISR_JOVRF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_JOVRIE) != 0U))
   {
     /* Clear injected overrun flag */
@@ -2910,7 +2910,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
 #endif /* USE_HAL_DFSDM_REGISTER_CALLBACKS */
   }
   /* Check if end of regular conversion */
-  else if (((temp_fltisr & DFSDM_FLTISR_REOCF) != 0U) && \
+  if (((temp_fltisr & DFSDM_FLTISR_REOCF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_REOCIE) != 0U))
   {
     /* Call regular conversion complete callback */
@@ -2933,7 +2933,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
     }
   }
   /* Check if end of injected conversion */
-  else if (((temp_fltisr & DFSDM_FLTISR_JEOCF) != 0U) && \
+  if (((temp_fltisr & DFSDM_FLTISR_JEOCF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_JEOCIE) != 0U))
   {
     /* Call injected conversion complete callback */
@@ -2963,7 +2963,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
     }
   }
   /* Check if analog watchdog occurs */
-  else if (((temp_fltisr & DFSDM_FLTISR_AWDF) != 0U) && \
+  if (((temp_fltisr & DFSDM_FLTISR_AWDF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_AWDIE) != 0U))
   {
     uint32_t reg;
@@ -2995,7 +2995,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
 #endif /* USE_HAL_DFSDM_REGISTER_CALLBACKS */
   }
   /* Check if clock absence occurs */
-  else if ((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
+  if ((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
            ((temp_fltisr & DFSDM_FLTISR_CKABF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_CKABIE) != 0U))
   {
@@ -3028,7 +3028,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
     }
   }
   /* Check if short circuit detection occurs */
-  else if ((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
+  if ((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
            ((temp_fltisr & DFSDM_FLTISR_SCDF) != 0U) && \
            ((temp_fltcr2 & DFSDM_FLTCR2_SCDIE) != 0U))
   {

--- a/stm32cube/stm32mp1xx/README
+++ b/stm32cube/stm32mp1xx/README
@@ -54,4 +54,12 @@ Patch List:
     Impacted files:
      drivers/include/Legacy/stm32_hal_legacy.h
 
+   *Fix HAL_DFSDM_IRQHandler
+      HAL_DFSDM_IRQHandler handles IRQ flags in an if {} else if {} condition.
+      This causes interrupts to be handled once and only the first flag
+      encountered in the condition, while there can be several flags raised.
+     Impacted files:
+       drivers/src/stm32f7xx_hal_dfsdm.c
+     ST Internal Reference: HAL1-27454
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32mp1xx/drivers/src/stm32mp1xx_hal_dfsdm.c
+++ b/stm32cube/stm32mp1xx/drivers/src/stm32mp1xx_hal_dfsdm.c
@@ -2911,7 +2911,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
 #endif
   }
   /* Check if overrun occurs during injected conversion */
-  else if(((temp_fltisr & DFSDM_FLTISR_JOVRF) != 0U) && \
+  if(((temp_fltisr & DFSDM_FLTISR_JOVRF) != 0U) && \
           ((temp_fltcr2 & DFSDM_FLTCR2_JOVRIE) != 0U))
   {
     /* Clear injected overrun flag */
@@ -2928,7 +2928,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
 #endif
   }
   /* Check if end of regular conversion */
-  else if(((temp_fltisr & DFSDM_FLTISR_REOCF) != 0U) && \
+  if(((temp_fltisr & DFSDM_FLTISR_REOCF) != 0U) && \
           ((temp_fltcr2 & DFSDM_FLTCR2_REOCIE) != 0U))
   {
     /* Call regular conversion complete callback */
@@ -2951,7 +2951,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
     }
   }
   /* Check if end of injected conversion */
-  else if(((temp_fltisr & DFSDM_FLTISR_JEOCF) != 0U) && \
+  if(((temp_fltisr & DFSDM_FLTISR_JEOCF) != 0U) && \
           ((temp_fltcr2 & DFSDM_FLTCR2_JEOCIE) != 0U))
   {
     /* Call injected conversion complete callback */
@@ -2981,7 +2981,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
     }
   }
   /* Check if analog watchdog occurs */
-  else if(((temp_fltisr & DFSDM_FLTISR_AWDF) != 0U) && \
+  if(((temp_fltisr & DFSDM_FLTISR_AWDF) != 0U) && \
           ((temp_fltcr2 & DFSDM_FLTCR2_AWDIE) != 0U))
   {
     uint32_t reg;
@@ -3013,7 +3013,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
 #endif
   }
   /* Check if clock absence occurs */
-  else if((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
+  if((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
          ((temp_fltisr & DFSDM_FLTISR_CKABF) != 0U) && \
          ((temp_fltcr2 & DFSDM_FLTCR2_CKABIE) != 0U))
   {
@@ -3046,7 +3046,7 @@ void HAL_DFSDM_IRQHandler(DFSDM_Filter_HandleTypeDef *hdfsdm_filter)
     }
   }
   /* Check if short circuit detection occurs */
-  else if((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
+  if((hdfsdm_filter->Instance == DFSDM1_Filter0) && \
          ((temp_fltisr & DFSDM_FLTISR_SCDF) != 0U) && \
          ((temp_fltcr2 & DFSDM_FLTCR2_SCDIE) != 0U))
   {


### PR DESCRIPTION
This PR fixes the `HAL_DFSDM_IRQHandler` across all SoCs that include this IP.
It also adds an entry to document the fix each README platform.