### PR TITLE
stm32cube: stm32mp13xx: ethernet adapt ref clock enum

### DIFF
--- a/stm32cube/stm32mp13xx/README
+++ b/stm32cube/stm32mp13xx/README
@@ -73,4 +73,14 @@ Patch List:
        drivers/src/stm32mp13xx_hal_dfsdm.c
      ST Internal Reference: HAL1-27454
 
+   *ethernet: Modify RMII reference clock enumeration
+     The way the HAL implements the ETH_ClkSrcTypeDef is not instance
+     agnostic. Add generic enum members that can target either ETH1 or
+     ETH2. The HAL driver is responsible to know on which controller
+     instance we are.
+     Impacted file:
+      stm32cube/stm32mp13xx/drivers/include/stm32mp13xx_hal_eth.h
+      stm32cube/stm32mp13xx/drivers/src/stm32mp13xx_hal_eth.c
+     Internal reference: HAL1-27631
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32mp13xx/drivers/include/stm32mp13xx_hal_eth.h
+++ b/stm32cube/stm32mp13xx/drivers/include/stm32mp13xx_hal_eth.h
@@ -414,10 +414,13 @@ typedef enum
   */
 typedef enum
 {
-  HAL_ETH1_REF_CLK_RCC         = 0x00U,   /*!<  ETH1 reference clock (RMII mode) comes from the RCC */
-  HAL_ETH1_REF_CLK_RX_CLK_PIN  = 0x01U,   /*!<  ETH1 reference clock (RMII mode) comes from the ETH2_RX_CLK/ETH2_REF_CLK pin */
-  HAL_ETH2_REF_CLK_RCC         = 0x02U,   /*!<  ETH2 reference clock (RMII mode) comes from the RCC */
-  HAL_ETH2_REF_CLK_RX_CLK_PIN  = 0x03U,   /*!<  ETH2 reference clock (RMII mode) comes from the ETH2_RX_CLK/ETH2_REF_CLK pin */
+  HAL_ETH_REF_CLK_RCC             = 0x00U,  /*!<  ETH1/2 reference clock (RMII mode) comes from the RCC */
+  HAL_ETH_REF_CLK_RX_CLK_PIN      = 0x01U,  /*!<  ETH1/2 reference clock (RMII mode) comes from the ETH_RX_CLK/ETH_REF_CLK pin */
+
+  HAL_ETH1_REF_CLK_RCC            = HAL_ETH_REF_CLK_RCC,
+  HAL_ETH1_REF_CLK_RX_CLK_PIN     = HAL_ETH_REF_CLK_RX_CLK_PIN,
+  HAL_ETH2_REF_CLK_RCC            = HAL_ETH_REF_CLK_RCC,
+  HAL_ETH2_REF_CLK_RX_CLK_PIN     = HAL_ETH_REF_CLK_RX_CLK_PIN
 } ETH_ClkSrcTypeDef;
 
 /**

--- a/stm32cube/stm32mp13xx/drivers/src/stm32mp13xx_hal_eth.c
+++ b/stm32cube/stm32mp13xx/drivers/src/stm32mp13xx_hal_eth.c
@@ -369,7 +369,7 @@ HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
     if (heth->Instance == ETH)
     {
       syscfg_config = SYSCFG_ETH1_RMII;
-      if (heth->Init.ClockSelection == HAL_ETH1_REF_CLK_RCC)
+      if (heth->Init.ClockSelection == HAL_ETH_REF_CLK_RCC)
       {
         syscfg_config |= SYSCFG_PMCSETR_ETH1_REF_CLK_SEL;
       }
@@ -378,7 +378,7 @@ HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
     else
     {
       syscfg_config = SYSCFG_ETH2_RMII;
-      if (heth->Init.ClockSelection == HAL_ETH2_REF_CLK_RCC)
+      if (heth->Init.ClockSelection == HAL_ETH_REF_CLK_RCC)
       {
         syscfg_config |= SYSCFG_PMCSETR_ETH2_REF_CLK_SEL;
       }


### PR DESCRIPTION
Today the RMII Reference clock enum is not instance agnostic. As it is done for other enumerations, this is up to the HAL to apply the configuration on the right Ethernet instance. If not, upper layers have to handle it themselves, that is not their role.

Remove HAL_ETH1_REF_CLK_RCC and HAL_ETH1_REF_CLK_RX_CLK_PIN to replace by generic ones.
Remove ETH2 ones that will use the same as ETH1.