### PR TITLE
Re-generate pinctrl files

### DIFF
--- a/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
@@ -698,6 +698,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
@@ -875,6 +875,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
@@ -1379,6 +1379,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
@@ -1379,6 +1379,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
@@ -917,6 +917,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
@@ -1124,6 +1124,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
@@ -698,6 +698,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
@@ -875,6 +875,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
@@ -1379,6 +1379,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
@@ -1379,6 +1379,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
@@ -917,6 +917,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
@@ -1124,6 +1124,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f3/stm32f302v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(b-c)tx-pinctrl.dtsi
@@ -797,6 +797,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
@@ -1025,6 +1025,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
@@ -1025,6 +1025,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/f3/stm32f302vcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302vcyx-pinctrl.dtsi
@@ -753,6 +753,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
@@ -1269,6 +1269,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/f3/stm32f303v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(b-c)tx-pinctrl.dtsi
@@ -1001,6 +1001,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
@@ -1217,6 +1217,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
@@ -1217,6 +1217,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/f3/stm32f303vcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303vcyx-pinctrl.dtsi
@@ -933,6 +933,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/f3/stm32f303veyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303veyx-pinctrl.dtsi
@@ -1113,6 +1113,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
@@ -1461,6 +1461,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/f3/stm32f358vctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358vctx-pinctrl.dtsi
@@ -989,6 +989,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/f3/stm32f373v(8-b-c)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373v(8-b-c)hx-pinctrl.dtsi
@@ -825,6 +825,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/f3/stm32f373v(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373v(8-b-c)tx-pinctrl.dtsi
@@ -825,6 +825,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/f3/stm32f378vchx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378vchx-pinctrl.dtsi
@@ -821,6 +821,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/f3/stm32f378vctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378vctx-pinctrl.dtsi
@@ -821,6 +821,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/f3/stm32f398vetx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f398vetx-pinctrl.dtsi
@@ -1205,6 +1205,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/f4/stm32f401v(b-c)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(b-c)hx-pinctrl.dtsi
@@ -582,6 +582,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f401v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(b-c)tx-pinctrl.dtsi
@@ -576,6 +576,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f401v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(d-e)hx-pinctrl.dtsi
@@ -582,6 +582,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f401v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(d-e)tx-pinctrl.dtsi
@@ -576,6 +576,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
@@ -720,6 +720,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
@@ -897,6 +897,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
@@ -1406,6 +1406,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
@@ -1406,6 +1406,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
@@ -939,6 +939,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
@@ -1146,6 +1146,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f410r(8-b)ix-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410r(8-b)ix-pinctrl.dtsi
@@ -475,6 +475,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced3_pb11: sys_traced3_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pc6: sys_traceclk_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc10: sys_traced0_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc11: sys_traced1_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pc12: sys_traced2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/f4/stm32f410r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410r(8-b)tx-pinctrl.dtsi
@@ -475,6 +475,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced3_pb11: sys_traced3_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pc6: sys_traceclk_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc10: sys_traced0_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc11: sys_traced1_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pc12: sys_traced2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/f4/stm32f411v(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411v(c-e)hx-pinctrl.dtsi
@@ -727,6 +727,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f411v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411v(c-e)tx-pinctrl.dtsi
@@ -721,6 +721,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f412v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412v(e-g)hx-pinctrl.dtsi
@@ -883,6 +883,30 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pd3: sys_traced1_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* QUADSPI */
 
 	/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f412v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412v(e-g)tx-pinctrl.dtsi
@@ -877,6 +877,30 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pd3: sys_traced1_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* QUADSPI */
 
 	/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f412z(e-g)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412z(e-g)jx-pinctrl.dtsi
@@ -1050,6 +1050,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pd3: sys_traced1_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pf6: sys_traced0_pf6 {
+		pinmux = <STM32_PINMUX('F', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pf7: sys_traced1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pg13: sys_traced2_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pg14: sys_traced3_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* QUADSPI */
 
 	/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f412z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412z(e-g)tx-pinctrl.dtsi
@@ -1050,6 +1050,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pd3: sys_traced1_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pf6: sys_traced0_pf6 {
+		pinmux = <STM32_PINMUX('F', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pf7: sys_traced1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pg13: sys_traced2_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pg14: sys_traced3_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* QUADSPI */
 
 	/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
@@ -1124,6 +1124,30 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pd3: sys_traced1_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
@@ -1118,6 +1118,30 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pd3: sys_traced1_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
@@ -1291,6 +1291,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pd3: sys_traced1_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pf6: sys_traced0_pf6 {
+		pinmux = <STM32_PINMUX('F', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pf7: sys_traced1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pg13: sys_traced2_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pg14: sys_traced3_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
@@ -1291,6 +1291,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pd3: sys_traced1_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pf6: sys_traced0_pf6 {
+		pinmux = <STM32_PINMUX('F', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pf7: sys_traced1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pg13: sys_traced2_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pg14: sys_traced3_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
@@ -720,6 +720,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
@@ -897,6 +897,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
@@ -1406,6 +1406,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
@@ -1406,6 +1406,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
@@ -939,6 +939,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
@@ -1146,6 +1146,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
@@ -1124,6 +1124,30 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pd3: sys_traced1_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
@@ -1118,6 +1118,30 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pd3: sys_traced1_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
@@ -1291,6 +1291,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pd3: sys_traced1_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pf6: sys_traced0_pf6 {
+		pinmux = <STM32_PINMUX('F', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pf7: sys_traced1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pg13: sys_traced2_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pg14: sys_traced3_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
@@ -1291,6 +1291,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pd3: sys_traced1_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pf6: sys_traced0_pf6 {
+		pinmux = <STM32_PINMUX('F', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pf7: sys_traced1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pg13: sys_traced2_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pg14: sys_traced3_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
@@ -1888,6 +1888,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
@@ -1983,6 +1983,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
@@ -1983,6 +1983,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
@@ -1194,6 +1194,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
@@ -1575,6 +1575,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
@@ -1888,6 +1888,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_b5_pa3: ltdc_b5_pa3 {

--- a/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
@@ -2095,6 +2095,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_b5_pa3: ltdc_b5_pa3 {

--- a/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
@@ -1983,6 +1983,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_b5_pa3: ltdc_b5_pa3 {

--- a/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
@@ -1983,6 +1983,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_b5_pa3: ltdc_b5_pa3 {

--- a/dts/st/f4/stm32f429iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429iitx-pinctrl.dtsi
@@ -1983,6 +1983,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_b5_pa3: ltdc_b5_pa3 {

--- a/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
@@ -2095,6 +2095,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_b5_pa3: ltdc_b5_pa3 {

--- a/dts/st/f4/stm32f429nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429nihx-pinctrl.dtsi
@@ -2095,6 +2095,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_b5_pa3: ltdc_b5_pa3 {

--- a/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
@@ -1164,6 +1164,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_b5_pa3: ltdc_b5_pa3 {

--- a/dts/st/f4/stm32f429vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429vitx-pinctrl.dtsi
@@ -1164,6 +1164,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_b5_pa3: ltdc_b5_pa3 {

--- a/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
@@ -1575,6 +1575,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_b5_pa3: ltdc_b5_pa3 {

--- a/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
@@ -1575,6 +1575,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_b5_pa3: ltdc_b5_pa3 {

--- a/dts/st/f4/stm32f429zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zitx-pinctrl.dtsi
@@ -1575,6 +1575,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_b5_pa3: ltdc_b5_pa3 {

--- a/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
@@ -1575,6 +1575,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_b5_pa3: ltdc_b5_pa3 {

--- a/dts/st/f4/stm32f437aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437aihx-pinctrl.dtsi
@@ -1888,6 +1888,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
@@ -1983,6 +1983,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
@@ -1983,6 +1983,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
@@ -1194,6 +1194,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
@@ -1575,6 +1575,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/f4/stm32f439aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439aihx-pinctrl.dtsi
@@ -1888,6 +1888,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_b5_pa3: ltdc_b5_pa3 {

--- a/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
@@ -2095,6 +2095,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_b5_pa3: ltdc_b5_pa3 {

--- a/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
@@ -1983,6 +1983,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_b5_pa3: ltdc_b5_pa3 {

--- a/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
@@ -1983,6 +1983,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_b5_pa3: ltdc_b5_pa3 {

--- a/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
@@ -2095,6 +2095,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_b5_pa3: ltdc_b5_pa3 {

--- a/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
@@ -1164,6 +1164,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_b5_pa3: ltdc_b5_pa3 {

--- a/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
@@ -1575,6 +1575,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_b5_pa3: ltdc_b5_pa3 {

--- a/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
@@ -1575,6 +1575,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_b5_pa3: ltdc_b5_pa3 {

--- a/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
@@ -803,6 +803,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc8: sys_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
 	/* QUADSPI */
 
 	/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
@@ -748,6 +748,10 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc8: sys_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
 	/* QUADSPI */
 
 	/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
@@ -1175,6 +1175,34 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc8: sys_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pd3: sys_traced1_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* QUADSPI */
 
 	/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
@@ -1558,6 +1558,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc8: sys_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pd3: sys_traced1_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pg13: sys_traced2_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pg14: sys_traced3_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* QUADSPI */
 
 	/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
@@ -1558,6 +1558,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc8: sys_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pd3: sys_traced1_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pg13: sys_traced2_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pg14: sys_traced3_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* QUADSPI */
 
 	/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
@@ -1558,6 +1558,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc8: sys_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pd3: sys_traced1_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pg13: sys_traced2_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pg14: sys_traced3_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* QUADSPI */
 
 	/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
@@ -1699,6 +1699,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {

--- a/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
@@ -1699,6 +1699,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {

--- a/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
@@ -2098,6 +2098,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {

--- a/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
@@ -1877,6 +1877,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {

--- a/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
@@ -1877,6 +1877,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {

--- a/dts/st/f4/stm32f469iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469iitx-pinctrl.dtsi
@@ -1877,6 +1877,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {

--- a/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
@@ -2098,6 +2098,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {

--- a/dts/st/f4/stm32f469nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469nihx-pinctrl.dtsi
@@ -2098,6 +2098,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {

--- a/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
@@ -951,6 +951,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {

--- a/dts/st/f4/stm32f469vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469vitx-pinctrl.dtsi
@@ -951,6 +951,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {

--- a/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
@@ -1415,6 +1415,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {

--- a/dts/st/f4/stm32f469zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469zitx-pinctrl.dtsi
@@ -1415,6 +1415,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {

--- a/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
@@ -1699,6 +1699,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {

--- a/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
@@ -1699,6 +1699,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {

--- a/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
@@ -2098,6 +2098,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {

--- a/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
@@ -1877,6 +1877,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {

--- a/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
@@ -1877,6 +1877,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {

--- a/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
@@ -2098,6 +2098,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {

--- a/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
@@ -951,6 +951,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {

--- a/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
@@ -1415,6 +1415,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LTDC */
 
 	/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {

--- a/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
@@ -1655,6 +1655,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
@@ -1655,6 +1655,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
@@ -605,6 +605,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* QUADSPI */
 
 	/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
@@ -1013,6 +1013,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
@@ -1352,6 +1352,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
@@ -1637,6 +1637,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
@@ -1637,6 +1637,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f723rcvx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723rcvx-pinctrl.dtsi
@@ -610,6 +610,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* QUADSPI */
 
 	/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f723revx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723revx-pinctrl.dtsi
@@ -610,6 +610,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* QUADSPI */
 
 	/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f723v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)tx-pinctrl.dtsi
@@ -979,6 +979,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
@@ -979,6 +979,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
@@ -1334,6 +1334,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
@@ -1334,6 +1334,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
@@ -1637,6 +1637,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
@@ -605,6 +605,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* QUADSPI */
 
 	/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
@@ -1013,6 +1013,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
@@ -1334,6 +1334,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f732iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732iekx-pinctrl.dtsi
@@ -1655,6 +1655,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f732ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732ietx-pinctrl.dtsi
@@ -1655,6 +1655,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f732retx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732retx-pinctrl.dtsi
@@ -605,6 +605,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* QUADSPI */
 
 	/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f732vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732vetx-pinctrl.dtsi
@@ -1013,6 +1013,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f732zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732zetx-pinctrl.dtsi
@@ -1352,6 +1352,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f733iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733iekx-pinctrl.dtsi
@@ -1637,6 +1637,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f733ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733ietx-pinctrl.dtsi
@@ -1637,6 +1637,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f733vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733vetx-pinctrl.dtsi
@@ -979,6 +979,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f733veyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733veyx-pinctrl.dtsi
@@ -979,6 +979,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f733zeix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zeix-pinctrl.dtsi
@@ -1334,6 +1334,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f733zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zetx-pinctrl.dtsi
@@ -1334,6 +1334,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
@@ -2112,6 +2112,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
@@ -2112,6 +2112,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
@@ -1277,6 +1277,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
@@ -1277,6 +1277,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
@@ -1687,6 +1687,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
@@ -2224,6 +2224,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
@@ -2112,6 +2112,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f746ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746ietx-pinctrl.dtsi
@@ -2112,6 +2112,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f746igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746igtx-pinctrl.dtsi
@@ -2112,6 +2112,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f746nehx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nehx-pinctrl.dtsi
@@ -2224,6 +2224,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f746nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nghx-pinctrl.dtsi
@@ -2224,6 +2224,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
@@ -1277,6 +1277,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f746vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vetx-pinctrl.dtsi
@@ -1277,6 +1277,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
@@ -1277,6 +1277,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
@@ -1687,6 +1687,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f746zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zetx-pinctrl.dtsi
@@ -1687,6 +1687,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
@@ -1687,6 +1687,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
@@ -2224,6 +2224,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
@@ -1277,6 +1277,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
@@ -1687,6 +1687,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
@@ -2224,6 +2224,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f756igkx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igkx-pinctrl.dtsi
@@ -2112,6 +2112,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f756igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igtx-pinctrl.dtsi
@@ -2112,6 +2112,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f756nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756nghx-pinctrl.dtsi
@@ -2224,6 +2224,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f756vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vghx-pinctrl.dtsi
@@ -1277,6 +1277,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
@@ -1277,6 +1277,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
@@ -1687,6 +1687,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
@@ -1687,6 +1687,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
@@ -2585,6 +2585,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
@@ -2473,6 +2473,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
@@ -2473,6 +2473,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
@@ -2585,6 +2585,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
@@ -1608,6 +1608,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
@@ -1608,6 +1608,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
@@ -2043,6 +2043,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
@@ -2585,6 +2585,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
@@ -2473,6 +2473,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
@@ -2473,6 +2473,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
@@ -2585,6 +2585,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f767vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vghx-pinctrl.dtsi
@@ -1608,6 +1608,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
@@ -1608,6 +1608,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f767vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vihx-pinctrl.dtsi
@@ -1608,6 +1608,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f767vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vitx-pinctrl.dtsi
@@ -1608,6 +1608,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
@@ -2043,6 +2043,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f767zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zitx-pinctrl.dtsi
@@ -2043,6 +2043,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
@@ -2120,6 +2120,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
@@ -2120,6 +2120,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
@@ -2549,6 +2549,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f769igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769igtx-pinctrl.dtsi
@@ -2306,6 +2306,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f769iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769iitx-pinctrl.dtsi
@@ -2306,6 +2306,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f769nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nghx-pinctrl.dtsi
@@ -2549,6 +2549,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f769nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nihx-pinctrl.dtsi
@@ -2549,6 +2549,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f777bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777bitx-pinctrl.dtsi
@@ -2585,6 +2585,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f777iikx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iikx-pinctrl.dtsi
@@ -2473,6 +2473,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f777iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iitx-pinctrl.dtsi
@@ -2473,6 +2473,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f777nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777nihx-pinctrl.dtsi
@@ -2585,6 +2585,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f777vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vihx-pinctrl.dtsi
@@ -1608,6 +1608,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f777vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vitx-pinctrl.dtsi
@@ -1608,6 +1608,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f777zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777zitx-pinctrl.dtsi
@@ -2043,6 +2043,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
@@ -2120,6 +2120,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
@@ -2120,6 +2120,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f779bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779bitx-pinctrl.dtsi
@@ -2549,6 +2549,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f779iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779iitx-pinctrl.dtsi
@@ -2306,6 +2306,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/f7/stm32f779nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779nihx-pinctrl.dtsi
@@ -2549,6 +2549,50 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc8: sys_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pg13: sys_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pg14: sys_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {

--- a/dts/st/g4/stm32g414vbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g414vbtx-pinctrl.dtsi
@@ -976,6 +976,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g414vctx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g414vctx-pinctrl.dtsi
@@ -976,6 +976,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
@@ -866,6 +866,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
@@ -866,6 +866,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
@@ -1128,6 +1128,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
@@ -976,6 +976,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
@@ -976,6 +976,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
@@ -976,6 +976,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g473p(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473p(b-c-e)ix-pinctrl.dtsi
@@ -1619,6 +1619,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
@@ -1692,6 +1692,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g473qetxz-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473qetxz-pinctrl.dtsi
@@ -1692,6 +1692,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
@@ -1414,6 +1414,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
@@ -1414,6 +1414,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g474p(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474p(b-c-e)ix-pinctrl.dtsi
@@ -1733,6 +1733,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
@@ -1806,6 +1806,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
@@ -1528,6 +1528,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
@@ -1528,6 +1528,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g483peix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483peix-pinctrl.dtsi
@@ -1619,6 +1619,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g483qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483qetx-pinctrl.dtsi
@@ -1692,6 +1692,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g483vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vehx-pinctrl.dtsi
@@ -1414,6 +1414,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g483vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vetx-pinctrl.dtsi
@@ -1414,6 +1414,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g484peix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484peix-pinctrl.dtsi
@@ -1733,6 +1733,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g484qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484qetx-pinctrl.dtsi
@@ -1806,6 +1806,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g484vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vehx-pinctrl.dtsi
@@ -1528,6 +1528,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g484vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vetx-pinctrl.dtsi
@@ -1528,6 +1528,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g491v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491v(c-e)tx-pinctrl.dtsi
@@ -942,6 +942,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/g4/stm32g4a1vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1vetx-pinctrl.dtsi
@@ -942,6 +942,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/h5/stm32h503cbtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h503cbtx-pinctrl.dtsi
@@ -547,6 +547,106 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa0: i2s1_sdi_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF12)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pa3: i2s1_sdi_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pa9: i2s1_sdi_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pa7: i2s2_sdi_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pa15: i2s2_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa2: i2s3_sdi_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa4: i2s3_sdi_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF10)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb15: i2s3_sdi_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa4: i2s1_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb1: i2s2_sdo_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa5: i2s3_sdo_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF10)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa9: i2s3_sdo_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF10)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa1: i2s1_ws_pa1 {
@@ -662,6 +762,14 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced2_pa9: debug_traced2_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pa12: debug_traced3_pa12 {
+		pinmux = <STM32_PINMUX('A', 12, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -680,6 +788,22 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb5: debug_traceclk_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb6: debug_traced0_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pb7: debug_traced1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb8: debug_traced2_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1786,6 +1910,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h503cbux-pinctrl.dtsi
+++ b/dts/st/h5/stm32h503cbux-pinctrl.dtsi
@@ -547,6 +547,106 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa0: i2s1_sdi_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF12)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pa3: i2s1_sdi_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pa9: i2s1_sdi_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pa7: i2s2_sdi_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pa15: i2s2_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa2: i2s3_sdi_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa4: i2s3_sdi_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF10)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb15: i2s3_sdi_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa4: i2s1_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb1: i2s2_sdo_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa5: i2s3_sdo_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF10)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa9: i2s3_sdo_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF10)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa1: i2s1_ws_pa1 {
@@ -662,6 +762,14 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced2_pa9: debug_traced2_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pa12: debug_traced3_pa12 {
+		pinmux = <STM32_PINMUX('A', 12, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -680,6 +788,22 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb5: debug_traceclk_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb6: debug_traced0_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pb7: debug_traced1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb8: debug_traced2_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1786,6 +1910,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h503ebyx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h503ebyx-pinctrl.dtsi
@@ -366,6 +366,70 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa0: i2s1_sdi_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF12)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pa9: i2s1_sdi_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pa7: i2s2_sdi_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pa15: i2s2_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb15: i2s3_sdi_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa5: i2s3_sdo_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF10)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa9: i2s3_sdo_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF10)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa15: i2s1_ws_pa15 {
@@ -442,6 +506,14 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced2_pa9: debug_traced2_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pa12: debug_traced3_pa12 {
+		pinmux = <STM32_PINMUX('A', 12, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -460,6 +532,22 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb5: debug_traceclk_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb6: debug_traced0_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pb7: debug_traced1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb8: debug_traced2_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1185,6 +1273,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h503kbux-pinctrl.dtsi
+++ b/dts/st/h5/stm32h503kbux-pinctrl.dtsi
@@ -452,6 +452,98 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa0: i2s1_sdi_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF12)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pa3: i2s1_sdi_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pa9: i2s1_sdi_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pa7: i2s2_sdi_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pa15: i2s2_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa2: i2s3_sdi_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa4: i2s3_sdi_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF10)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb15: i2s3_sdi_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa4: i2s1_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb1: i2s2_sdo_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa5: i2s3_sdo_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF10)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa9: i2s3_sdo_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF10)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa1: i2s1_ws_pa1 {
@@ -544,6 +636,14 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced2_pa9: debug_traced2_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pa12: debug_traced3_pa12 {
+		pinmux = <STM32_PINMUX('A', 12, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -562,6 +662,22 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb5: debug_traceclk_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb6: debug_traced0_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pb7: debug_traced1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb8: debug_traced2_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1522,6 +1638,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h503rbtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h503rbtx-pinctrl.dtsi
@@ -757,6 +757,142 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa0: i2s1_sdi_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF12)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pa3: i2s1_sdi_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pa9: i2s1_sdi_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc2: i2s1_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc10: i2s1_sdi_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pa7: i2s2_sdi_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pa15: i2s2_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa2: i2s3_sdi_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa4: i2s3_sdi_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF10)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb15: i2s3_sdi_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa4: i2s1_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc3: i2s1_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc7: i2s1_sdo_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb1: i2s2_sdo_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa5: i2s3_sdo_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF10)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa9: i2s3_sdo_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF10)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa1: i2s1_ws_pa1 {
@@ -914,6 +1050,14 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced2_pa9: debug_traced2_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pa12: debug_traced3_pa12 {
+		pinmux = <STM32_PINMUX('A', 12, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -932,6 +1076,38 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb5: debug_traceclk_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb6: debug_traced0_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pb7: debug_traced1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb8: debug_traced2_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2331,6 +2507,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h523cctx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h523cctx-pinctrl.dtsi
@@ -433,6 +433,62 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb0: i2s3_sdi_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa4: i2s3_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1332,6 +1388,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h523ccux-pinctrl.dtsi
+++ b/dts/st/h5/stm32h523ccux-pinctrl.dtsi
@@ -433,6 +433,62 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb0: i2s3_sdi_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa4: i2s3_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1332,6 +1388,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h523cetx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h523cetx-pinctrl.dtsi
@@ -433,6 +433,62 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb0: i2s3_sdi_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa4: i2s3_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1332,6 +1388,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h523ceux-pinctrl.dtsi
+++ b/dts/st/h5/stm32h523ceux-pinctrl.dtsi
@@ -433,6 +433,62 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb0: i2s3_sdi_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa4: i2s3_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1332,6 +1388,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h523heyx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h523heyx-pinctrl.dtsi
@@ -305,6 +305,30 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -905,6 +929,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h523rctx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h523rctx-pinctrl.dtsi
@@ -699,6 +699,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb0: i2s3_sdi_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa4: i2s3_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -820,6 +896,22 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1963,6 +2055,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h523retx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h523retx-pinctrl.dtsi
@@ -699,6 +699,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb0: i2s3_sdi_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa4: i2s3_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -820,6 +896,22 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1963,6 +2055,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h523vcix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h523vcix-pinctrl.dtsi
@@ -1203,6 +1203,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb0: i2s3_sdi_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd7: i2s3_sdi_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa4: i2s3_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1353,6 +1441,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2864,6 +2988,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h523vctx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h523vctx-pinctrl.dtsi
@@ -1203,6 +1203,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb0: i2s3_sdi_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd7: i2s3_sdi_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa4: i2s3_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1353,6 +1441,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2864,6 +2988,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h523veix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h523veix-pinctrl.dtsi
@@ -1203,6 +1203,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb0: i2s3_sdi_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd7: i2s3_sdi_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa4: i2s3_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1353,6 +1441,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2864,6 +2988,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h523vetx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h523vetx-pinctrl.dtsi
@@ -1203,6 +1203,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb0: i2s3_sdi_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd7: i2s3_sdi_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa4: i2s3_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1353,6 +1441,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2864,6 +2988,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h523zcjx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h523zcjx-pinctrl.dtsi
@@ -1570,6 +1570,106 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb0: i2s3_sdi_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd7: i2s3_sdi_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa4: i2s3_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pg8: i2s3_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1754,6 +1854,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3435,6 +3579,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h523zctx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h523zctx-pinctrl.dtsi
@@ -1570,6 +1570,106 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb0: i2s3_sdi_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd7: i2s3_sdi_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa4: i2s3_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pg8: i2s3_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1754,6 +1854,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3435,6 +3579,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h523zejx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h523zejx-pinctrl.dtsi
@@ -1570,6 +1570,106 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb0: i2s3_sdi_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd7: i2s3_sdi_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa4: i2s3_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pg8: i2s3_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1754,6 +1854,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3435,6 +3579,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h523zetx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h523zetx-pinctrl.dtsi
@@ -1570,6 +1570,106 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb0: i2s3_sdi_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd7: i2s3_sdi_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa4: i2s3_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pg8: i2s3_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1754,6 +1854,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3435,6 +3579,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h533cetx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h533cetx-pinctrl.dtsi
@@ -433,6 +433,62 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb0: i2s3_sdi_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa4: i2s3_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1332,6 +1388,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h533ceux-pinctrl.dtsi
+++ b/dts/st/h5/stm32h533ceux-pinctrl.dtsi
@@ -433,6 +433,62 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb0: i2s3_sdi_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa4: i2s3_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1332,6 +1388,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h533heyx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h533heyx-pinctrl.dtsi
@@ -305,6 +305,30 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -905,6 +929,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h533retx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h533retx-pinctrl.dtsi
@@ -699,6 +699,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb0: i2s3_sdi_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa4: i2s3_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -820,6 +896,22 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1963,6 +2055,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h533veix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h533veix-pinctrl.dtsi
@@ -1203,6 +1203,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb0: i2s3_sdi_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd7: i2s3_sdi_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa4: i2s3_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1353,6 +1441,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2864,6 +2988,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h533vetx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h533vetx-pinctrl.dtsi
@@ -1203,6 +1203,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb0: i2s3_sdi_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd7: i2s3_sdi_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa4: i2s3_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1353,6 +1441,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2864,6 +2988,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h533zejx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h533zejx-pinctrl.dtsi
@@ -1570,6 +1570,106 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb0: i2s3_sdi_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd7: i2s3_sdi_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa4: i2s3_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pg8: i2s3_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1754,6 +1854,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3435,6 +3579,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h533zetx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h533zetx-pinctrl.dtsi
@@ -1570,6 +1570,106 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb0: i2s3_sdi_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd7: i2s3_sdi_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb15: i2s1_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa3: i2s3_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa4: i2s3_sdo_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pg8: i2s3_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1754,6 +1854,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3435,6 +3579,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h562agix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562agix-pinctrl.dtsi
@@ -1939,6 +1939,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2069,6 +2153,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4565,6 +4693,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h562aiix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562aiix-pinctrl.dtsi
@@ -1939,6 +1939,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2069,6 +2153,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4565,6 +4693,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h562igkx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562igkx-pinctrl.dtsi
@@ -1978,6 +1978,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2108,6 +2192,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4634,6 +4762,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h562igtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562igtx-pinctrl.dtsi
@@ -1978,6 +1978,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2108,6 +2192,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4634,6 +4762,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h562iikx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562iikx-pinctrl.dtsi
@@ -1978,6 +1978,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2108,6 +2192,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4634,6 +4762,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h562iitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562iitx-pinctrl.dtsi
@@ -1978,6 +1978,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2108,6 +2192,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4634,6 +4762,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h562rgtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562rgtx-pinctrl.dtsi
@@ -683,6 +683,66 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -756,6 +816,22 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1998,6 +2074,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h562rgvx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562rgvx-pinctrl.dtsi
@@ -746,6 +746,66 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -833,6 +893,18 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2182,6 +2254,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h562ritx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562ritx-pinctrl.dtsi
@@ -683,6 +683,66 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -756,6 +816,22 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1998,6 +2074,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h562rivx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562rivx-pinctrl.dtsi
@@ -746,6 +746,66 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -833,6 +893,18 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2182,6 +2254,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h562vgtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562vgtx-pinctrl.dtsi
@@ -1237,6 +1237,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1329,6 +1397,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3135,6 +3239,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h562vitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562vitx-pinctrl.dtsi
@@ -1237,6 +1237,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1329,6 +1397,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3135,6 +3239,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h562zgtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562zgtx-pinctrl.dtsi
@@ -1647,6 +1647,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1763,6 +1839,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4034,6 +4154,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h562zitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h562zitx-pinctrl.dtsi
@@ -1647,6 +1647,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1763,6 +1839,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4034,6 +4154,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h563agix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563agix-pinctrl.dtsi
@@ -2125,6 +2125,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2255,6 +2339,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4877,6 +5005,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h563aiix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563aiix-pinctrl.dtsi
@@ -2125,6 +2125,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2255,6 +2339,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4877,6 +5005,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h563aiixq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563aiixq-pinctrl.dtsi
@@ -2095,6 +2095,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2225,6 +2309,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4769,6 +4889,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h563igkx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563igkx-pinctrl.dtsi
@@ -2169,6 +2169,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2299,6 +2383,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4951,6 +5079,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h563igtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563igtx-pinctrl.dtsi
@@ -2169,6 +2169,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2299,6 +2383,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4951,6 +5079,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h563iikx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563iikx-pinctrl.dtsi
@@ -2169,6 +2169,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2299,6 +2383,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4951,6 +5079,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h563iikxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563iikxq-pinctrl.dtsi
@@ -2160,6 +2160,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2286,6 +2370,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4928,6 +5056,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h563iitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563iitx-pinctrl.dtsi
@@ -2169,6 +2169,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2299,6 +2383,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4951,6 +5079,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h563iitxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563iitxq-pinctrl.dtsi
@@ -2119,6 +2119,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2249,6 +2333,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4868,6 +4996,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h563lihxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563lihxq-pinctrl.dtsi
@@ -2169,6 +2169,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2299,6 +2383,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4951,6 +5079,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h563miyxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563miyxq-pinctrl.dtsi
@@ -1026,6 +1026,66 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1099,6 +1159,22 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2471,6 +2547,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h563rgtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563rgtx-pinctrl.dtsi
@@ -810,6 +810,66 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -883,6 +943,22 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2125,6 +2201,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h563rgvx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563rgvx-pinctrl.dtsi
@@ -878,6 +878,66 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -965,6 +1025,18 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2314,6 +2386,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h563ritx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563ritx-pinctrl.dtsi
@@ -810,6 +810,66 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -883,6 +943,22 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2125,6 +2201,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h563rivx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563rivx-pinctrl.dtsi
@@ -878,6 +878,66 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -965,6 +1025,18 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2314,6 +2386,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h563vgtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563vgtx-pinctrl.dtsi
@@ -1373,6 +1373,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1465,6 +1533,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3271,6 +3375,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h563vitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563vitx-pinctrl.dtsi
@@ -1373,6 +1373,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1465,6 +1533,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3271,6 +3375,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h563vitxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563vitxq-pinctrl.dtsi
@@ -1214,6 +1214,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1302,6 +1370,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3058,6 +3162,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h563zgtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563zgtx-pinctrl.dtsi
@@ -1808,6 +1808,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1924,6 +2000,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4321,6 +4441,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h563zitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563zitx-pinctrl.dtsi
@@ -1808,6 +1808,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1924,6 +2000,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4321,6 +4441,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h563zitxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h563zitxq-pinctrl.dtsi
@@ -1629,6 +1629,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1741,6 +1817,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4067,6 +4187,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h573aiix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573aiix-pinctrl.dtsi
@@ -2125,6 +2125,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2255,6 +2339,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4877,6 +5005,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h573aiixq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573aiixq-pinctrl.dtsi
@@ -2095,6 +2095,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2225,6 +2309,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4769,6 +4889,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h573iikx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573iikx-pinctrl.dtsi
@@ -2169,6 +2169,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2299,6 +2383,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4951,6 +5079,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h573iikxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573iikxq-pinctrl.dtsi
@@ -2160,6 +2160,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2286,6 +2370,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4928,6 +5056,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h573iitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573iitx-pinctrl.dtsi
@@ -2169,6 +2169,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2299,6 +2383,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4951,6 +5079,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h573iitxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573iitxq-pinctrl.dtsi
@@ -2119,6 +2119,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2249,6 +2333,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4868,6 +4996,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h573lihxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573lihxq-pinctrl.dtsi
@@ -2169,6 +2169,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2299,6 +2383,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4951,6 +5079,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h573miyxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573miyxq-pinctrl.dtsi
@@ -1026,6 +1026,66 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1099,6 +1159,22 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2471,6 +2547,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h573ritx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573ritx-pinctrl.dtsi
@@ -810,6 +810,66 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -883,6 +943,22 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2125,6 +2201,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h573rivx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573rivx-pinctrl.dtsi
@@ -878,6 +878,66 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -965,6 +1025,18 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2314,6 +2386,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h573vitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573vitx-pinctrl.dtsi
@@ -1373,6 +1373,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1465,6 +1533,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3271,6 +3375,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h573vitxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573vitxq-pinctrl.dtsi
@@ -1214,6 +1214,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1302,6 +1370,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3058,6 +3162,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h573zitx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573zitx-pinctrl.dtsi
@@ -1808,6 +1808,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1924,6 +2000,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4321,6 +4441,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h573zitxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h573zitxq-pinctrl.dtsi
@@ -1629,6 +1629,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1741,6 +1817,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4067,6 +4187,10 @@
 	};
 
 	/* USB */
+
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
 
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF10)>;

--- a/dts/st/h5/stm32h5e4ajix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4ajix-pinctrl.dtsi
@@ -2697,6 +2697,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2872,6 +2960,70 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e4ajixq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4ajixq-pinctrl.dtsi
@@ -2657,6 +2657,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2832,6 +2920,62 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e4akix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4akix-pinctrl.dtsi
@@ -2697,6 +2697,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2872,6 +2960,70 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e4ijkx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4ijkx-pinctrl.dtsi
@@ -2746,6 +2746,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2921,6 +3009,70 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e4ijkxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4ijkxq-pinctrl.dtsi
@@ -2737,6 +2737,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2908,6 +2996,70 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e4ijtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4ijtx-pinctrl.dtsi
@@ -2746,6 +2746,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2921,6 +3009,70 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e4ijtxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4ijtxq-pinctrl.dtsi
@@ -2696,6 +2696,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2861,6 +2949,70 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e4ikkx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4ikkx-pinctrl.dtsi
@@ -2746,6 +2746,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2921,6 +3009,70 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e4iktx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4iktx-pinctrl.dtsi
@@ -2746,6 +2746,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2921,6 +3009,70 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e4vjtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4vjtx-pinctrl.dtsi
@@ -1753,6 +1753,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1865,6 +1933,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e4vjtxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4vjtxq-pinctrl.dtsi
@@ -1686,6 +1686,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1794,6 +1862,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e4vktx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4vktx-pinctrl.dtsi
@@ -1753,6 +1753,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1865,6 +1933,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e4zjjx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4zjjx-pinctrl.dtsi
@@ -2305,6 +2305,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2456,6 +2536,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e4zjjxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4zjjxq-pinctrl.dtsi
@@ -2257,6 +2257,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2399,6 +2479,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e4zjtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4zjtx-pinctrl.dtsi
@@ -2279,6 +2279,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2425,6 +2505,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e4zjtxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4zjtxq-pinctrl.dtsi
@@ -2213,6 +2213,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2355,6 +2435,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e4zkjx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4zkjx-pinctrl.dtsi
@@ -1691,6 +1691,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1842,6 +1922,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e4zktx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4zktx-pinctrl.dtsi
@@ -1671,6 +1671,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1817,6 +1897,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e5ijkxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e5ijkxq-pinctrl.dtsi
@@ -2737,6 +2737,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2908,6 +2996,70 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e5ijtxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e5ijtxq-pinctrl.dtsi
@@ -2602,6 +2602,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2767,6 +2855,66 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e5ikkxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e5ikkxq-pinctrl.dtsi
@@ -2737,6 +2737,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2908,6 +2996,70 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e5iktxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e5iktxq-pinctrl.dtsi
@@ -2602,6 +2602,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2767,6 +2855,66 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e5ljhxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e5ljhxq-pinctrl.dtsi
@@ -2998,6 +2998,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -3183,6 +3271,90 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pk11: debug_traceclk_pk11 {
+		pinmux = <STM32_PINMUX('K', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pk12: debug_traced0_pk12 {
+		pinmux = <STM32_PINMUX('K', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pk13: debug_traced1_pk13 {
+		pinmux = <STM32_PINMUX('K', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pk14: debug_traced2_pk14 {
+		pinmux = <STM32_PINMUX('K', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pk15: debug_traced3_pk15 {
+		pinmux = <STM32_PINMUX('K', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e5lkhxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e5lkhxq-pinctrl.dtsi
@@ -2998,6 +2998,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -3183,6 +3271,90 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pk11: debug_traceclk_pk11 {
+		pinmux = <STM32_PINMUX('K', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pk12: debug_traced0_pk12 {
+		pinmux = <STM32_PINMUX('K', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pk13: debug_traced1_pk13 {
+		pinmux = <STM32_PINMUX('K', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pk14: debug_traced2_pk14 {
+		pinmux = <STM32_PINMUX('K', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pk15: debug_traced3_pk15 {
+		pinmux = <STM32_PINMUX('K', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e5vjyxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e5vjyxq-pinctrl.dtsi
@@ -1684,6 +1684,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1796,6 +1864,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e5vkyxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e5vkyxq-pinctrl.dtsi
@@ -1684,6 +1684,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1796,6 +1864,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e5zjtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e5zjtx-pinctrl.dtsi
@@ -2185,6 +2185,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2331,6 +2411,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5e5zktx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e5zktx-pinctrl.dtsi
@@ -1625,6 +1625,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1771,6 +1851,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5f4ajix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4ajix-pinctrl.dtsi
@@ -2697,6 +2697,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2872,6 +2960,70 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5f4ajixq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4ajixq-pinctrl.dtsi
@@ -2657,6 +2657,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2832,6 +2920,62 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5f4ijkx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4ijkx-pinctrl.dtsi
@@ -2746,6 +2746,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2921,6 +3009,70 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5f4ijkxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4ijkxq-pinctrl.dtsi
@@ -2737,6 +2737,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2908,6 +2996,70 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5f4ijtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4ijtx-pinctrl.dtsi
@@ -2746,6 +2746,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2921,6 +3009,70 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5f4ijtxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4ijtxq-pinctrl.dtsi
@@ -2696,6 +2696,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2861,6 +2949,70 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5f4vjtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4vjtx-pinctrl.dtsi
@@ -1753,6 +1753,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1865,6 +1933,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5f4vjtxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4vjtxq-pinctrl.dtsi
@@ -1686,6 +1686,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1794,6 +1862,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5f4zjjx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4zjjx-pinctrl.dtsi
@@ -2305,6 +2305,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2456,6 +2536,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5f4zjjxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4zjjxq-pinctrl.dtsi
@@ -2257,6 +2257,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2399,6 +2479,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5f4zjtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4zjtx-pinctrl.dtsi
@@ -2279,6 +2279,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2425,6 +2505,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5f4zjtxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4zjtxq-pinctrl.dtsi
@@ -2213,6 +2213,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2355,6 +2435,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5f5ijkxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f5ijkxq-pinctrl.dtsi
@@ -2737,6 +2737,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2908,6 +2996,70 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5f5ijtxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f5ijtxq-pinctrl.dtsi
@@ -2602,6 +2602,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2767,6 +2855,66 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5f5ljhxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f5ljhxq-pinctrl.dtsi
@@ -2998,6 +2998,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -3183,6 +3271,90 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph15: debug_traceclk_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi1: debug_traced0_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi2: debug_traced1_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pi3: debug_traced2_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pi4: debug_traced3_pi4 {
+		pinmux = <STM32_PINMUX('I', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pk11: debug_traceclk_pk11 {
+		pinmux = <STM32_PINMUX('K', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pk12: debug_traced0_pk12 {
+		pinmux = <STM32_PINMUX('K', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pk13: debug_traced1_pk13 {
+		pinmux = <STM32_PINMUX('K', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pk14: debug_traced2_pk14 {
+		pinmux = <STM32_PINMUX('K', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pk15: debug_traced3_pk15 {
+		pinmux = <STM32_PINMUX('K', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5f5vjyxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f5vjyxq-pinctrl.dtsi
@@ -1684,6 +1684,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1796,6 +1864,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h5/stm32h5f5zjtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f5zjtx-pinctrl.dtsi
@@ -2185,6 +2185,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pf14: i2s3_sdi_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg1: i2s2_sdo_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2331,6 +2411,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h723vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vehx-pinctrl.dtsi
@@ -1679,6 +1679,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1745,6 +1829,42 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h723vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vetx-pinctrl.dtsi
@@ -1679,6 +1679,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1745,6 +1829,42 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h723vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vghx-pinctrl.dtsi
@@ -1679,6 +1679,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1745,6 +1829,42 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
@@ -1679,6 +1679,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1745,6 +1829,42 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h723zeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zeix-pinctrl.dtsi
@@ -2221,6 +2221,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2295,6 +2391,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h723zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zetx-pinctrl.dtsi
@@ -2193,6 +2193,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2267,6 +2363,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h723zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgix-pinctrl.dtsi
@@ -2221,6 +2221,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2295,6 +2391,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
@@ -2193,6 +2193,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2267,6 +2363,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h725aeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725aeix-pinctrl.dtsi
@@ -2468,6 +2468,110 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2546,6 +2650,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h725agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725agix-pinctrl.dtsi
@@ -2468,6 +2468,110 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2546,6 +2650,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h725iekx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725iekx-pinctrl.dtsi
@@ -2613,6 +2613,110 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2691,6 +2795,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h725ietx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725ietx-pinctrl.dtsi
@@ -2221,6 +2221,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2295,6 +2391,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h725igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igkx-pinctrl.dtsi
@@ -2613,6 +2613,110 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2691,6 +2795,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h725igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igtx-pinctrl.dtsi
@@ -2221,6 +2221,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2295,6 +2391,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h725revx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725revx-pinctrl.dtsi
@@ -824,6 +824,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -890,6 +958,18 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
@@ -824,6 +824,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -890,6 +958,18 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h725vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vehx-pinctrl.dtsi
@@ -1602,6 +1602,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1668,6 +1752,42 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h725vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vetx-pinctrl.dtsi
@@ -1464,6 +1464,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1530,6 +1606,34 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h725vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vghx-pinctrl.dtsi
@@ -1602,6 +1602,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1668,6 +1752,42 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
@@ -1464,6 +1464,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1530,6 +1606,34 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
@@ -1402,6 +1402,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1468,6 +1536,30 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h725zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zetx-pinctrl.dtsi
@@ -1966,6 +1966,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2040,6 +2136,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
@@ -1966,6 +1966,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2040,6 +2136,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h730abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730abixq-pinctrl.dtsi
@@ -2468,6 +2468,110 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2546,6 +2650,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
@@ -2613,6 +2613,110 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2691,6 +2795,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
@@ -2221,6 +2221,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2295,6 +2391,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
@@ -1679,6 +1679,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1745,6 +1829,42 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
@@ -1679,6 +1679,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1745,6 +1829,42 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h730zbix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbix-pinctrl.dtsi
@@ -2221,6 +2221,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2295,6 +2391,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
@@ -2193,6 +2193,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2267,6 +2363,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h733vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vghx-pinctrl.dtsi
@@ -1679,6 +1679,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1745,6 +1829,42 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
@@ -1679,6 +1679,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1745,6 +1829,42 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h733zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgix-pinctrl.dtsi
@@ -2221,6 +2221,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2295,6 +2391,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
@@ -2193,6 +2193,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2267,6 +2363,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h735agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735agix-pinctrl.dtsi
@@ -2468,6 +2468,110 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2546,6 +2650,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h735igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igkx-pinctrl.dtsi
@@ -2613,6 +2613,110 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2691,6 +2795,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h735igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igtx-pinctrl.dtsi
@@ -2221,6 +2221,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2295,6 +2391,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
@@ -824,6 +824,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -890,6 +958,18 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h735vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vghx-pinctrl.dtsi
@@ -1602,6 +1602,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1668,6 +1752,42 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
@@ -1464,6 +1464,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1530,6 +1606,34 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
@@ -1402,6 +1402,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1468,6 +1536,30 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
@@ -1966,6 +1966,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2040,6 +2136,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -2273,6 +2273,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2335,6 +2415,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -2572,6 +2572,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2634,6 +2714,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -2460,6 +2460,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2522,6 +2602,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -2460,6 +2460,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2522,6 +2602,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
@@ -1536,6 +1536,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1590,6 +1658,42 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
@@ -1536,6 +1536,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1590,6 +1658,42 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -2704,6 +2704,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2766,6 +2854,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -2012,6 +2012,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2070,6 +2142,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -2273,6 +2273,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2335,6 +2415,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -2572,6 +2572,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2634,6 +2714,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -2572,6 +2572,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2634,6 +2714,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -2460,6 +2460,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2522,6 +2602,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -2460,6 +2460,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2522,6 +2602,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -2460,6 +2460,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2522,6 +2602,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -2460,6 +2460,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2522,6 +2602,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -1536,6 +1536,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1590,6 +1658,42 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -1536,6 +1536,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1590,6 +1658,42 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -1536,6 +1536,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1590,6 +1658,42 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -2704,6 +2704,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2766,6 +2854,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -2704,6 +2704,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2766,6 +2854,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -2012,6 +2012,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2070,6 +2142,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -2012,6 +2012,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2070,6 +2142,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -2500,6 +2500,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2562,6 +2642,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -2500,6 +2500,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2562,6 +2642,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -2430,6 +2430,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2488,6 +2568,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -2040,6 +2040,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2098,6 +2170,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -2430,6 +2430,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2488,6 +2568,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -2040,6 +2040,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2098,6 +2170,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -2704,6 +2704,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2766,6 +2854,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -2704,6 +2704,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2766,6 +2854,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -1798,6 +1798,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1856,6 +1928,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -1798,6 +1798,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1856,6 +1928,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -2012,6 +2012,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2070,6 +2142,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -2464,6 +2464,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2526,6 +2606,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -2464,6 +2464,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2526,6 +2606,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -2012,6 +2012,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2070,6 +2142,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -2012,6 +2012,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2070,6 +2142,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -2704,6 +2704,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2766,6 +2854,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -2704,6 +2704,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2766,6 +2854,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -1825,6 +1825,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1879,6 +1947,42 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -2460,6 +2460,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2522,6 +2602,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -2460,6 +2460,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2522,6 +2602,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -1536,6 +1536,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1590,6 +1658,42 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -2704,6 +2704,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2766,6 +2854,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -2012,6 +2012,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2070,6 +2142,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -2273,6 +2273,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2335,6 +2415,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -2572,6 +2572,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2634,6 +2714,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -2460,6 +2460,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2522,6 +2602,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -2460,6 +2460,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2522,6 +2602,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -1536,6 +1536,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1590,6 +1658,42 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -1536,6 +1536,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1590,6 +1658,42 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -2704,6 +2704,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2766,6 +2854,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -2012,6 +2012,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2070,6 +2142,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -2500,6 +2500,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2562,6 +2642,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -2430,6 +2430,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2488,6 +2568,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -2040,6 +2040,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2098,6 +2170,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -2704,6 +2704,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2766,6 +2854,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -1798,6 +1798,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1856,6 +1928,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -2012,6 +2012,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2070,6 +2142,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -2464,6 +2464,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2526,6 +2606,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -2012,6 +2012,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2070,6 +2142,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -2704,6 +2704,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2766,6 +2854,50 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -1825,6 +1825,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1879,6 +1947,42 @@
 
 	/omit-if-no-ref/ debug_jtrst_pb4: debug_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
@@ -2103,6 +2103,110 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2181,6 +2285,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
@@ -2296,6 +2296,110 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2374,6 +2478,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
@@ -2226,6 +2226,110 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2304,6 +2408,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
@@ -2296,6 +2296,110 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2374,6 +2478,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
@@ -1929,6 +1929,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2003,6 +2099,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
@@ -2495,6 +2495,118 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2577,6 +2689,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
@@ -2408,6 +2408,110 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2486,6 +2590,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
@@ -1590,6 +1590,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1660,6 +1756,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
@@ -861,6 +861,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -927,6 +1003,18 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
@@ -1493,6 +1493,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1559,6 +1643,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
@@ -1416,6 +1416,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1482,6 +1566,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
@@ -1493,6 +1493,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1559,6 +1643,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
@@ -1293,6 +1293,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1359,6 +1435,34 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
@@ -1901,6 +1901,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1975,6 +2071,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
@@ -1707,6 +1707,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1781,6 +1877,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
@@ -2103,6 +2103,110 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2181,6 +2285,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
@@ -2226,6 +2226,110 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2304,6 +2408,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
@@ -2296,6 +2296,110 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2374,6 +2478,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
@@ -861,6 +861,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -927,6 +1003,18 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
@@ -1493,6 +1493,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1559,6 +1643,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
@@ -1901,6 +1901,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1975,6 +2071,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
@@ -2103,6 +2103,110 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2181,6 +2285,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
@@ -2296,6 +2296,110 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2374,6 +2478,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
@@ -2226,6 +2226,110 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2304,6 +2408,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
@@ -2296,6 +2296,110 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2374,6 +2478,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
@@ -1929,6 +1929,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2003,6 +2099,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -2495,6 +2495,118 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2577,6 +2689,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
@@ -2408,6 +2408,110 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2486,6 +2590,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
@@ -1590,6 +1590,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1660,6 +1756,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
@@ -861,6 +861,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -927,6 +1003,18 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
@@ -1493,6 +1493,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1559,6 +1643,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
@@ -1416,6 +1416,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1482,6 +1566,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
@@ -1493,6 +1493,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1559,6 +1643,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
@@ -1293,6 +1293,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1359,6 +1435,34 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
@@ -1901,6 +1901,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1975,6 +2071,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
@@ -1707,6 +1707,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2_c: i2s2_sdi_pc2_c {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3_c: i2s2_sdo_pc3_c {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1781,6 +1877,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/h7/stm32h7r3a8ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3a8ix-pinctrl.dtsi
@@ -1781,6 +1781,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1871,6 +1955,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3502,7 +3622,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 		pinmux = <STM32_PINMUX('O', 0, AF9)>;

--- a/dts/st/h7/stm32h7r3i8kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3i8kx-pinctrl.dtsi
@@ -1889,6 +1889,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1979,6 +2063,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3657,7 +3777,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 		pinmux = <STM32_PINMUX('O', 0, AF9)>;

--- a/dts/st/h7/stm32h7r3i8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3i8tx-pinctrl.dtsi
@@ -1848,6 +1848,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1938,6 +2022,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3591,7 +3711,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 		pinmux = <STM32_PINMUX('O', 0, AF9)>;

--- a/dts/st/h7/stm32h7r3l8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3l8hx-pinctrl.dtsi
@@ -2299,6 +2299,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2397,6 +2493,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4220,7 +4360,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/h7/stm32h7r3l8hxh-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3l8hxh-pinctrl.dtsi
@@ -2155,6 +2155,98 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2245,6 +2337,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3992,7 +4128,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/h7/stm32h7r3r8vx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3r8vx-pinctrl.dtsi
@@ -555,6 +555,46 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1273,7 +1313,7 @@
 		pinmux = <STM32_PINMUX('M', 14, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 		pinmux = <STM32_PINMUX('O', 0, AF9)>;

--- a/dts/st/h7/stm32h7r3v8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3v8hx-pinctrl.dtsi
@@ -702,6 +702,66 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -792,6 +852,10 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1587,7 +1651,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 		pinmux = <STM32_PINMUX('O', 0, AF9)>;

--- a/dts/st/h7/stm32h7r3v8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3v8tx-pinctrl.dtsi
@@ -743,6 +743,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -833,6 +901,14 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1743,7 +1819,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 		pinmux = <STM32_PINMUX('O', 0, AF9)>;

--- a/dts/st/h7/stm32h7r3v8yx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3v8yx-pinctrl.dtsi
@@ -702,6 +702,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -783,6 +851,10 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1565,7 +1637,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 		pinmux = <STM32_PINMUX('O', 0, AF9)>;

--- a/dts/st/h7/stm32h7r3z8jx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3z8jx-pinctrl.dtsi
@@ -1479,6 +1479,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1569,6 +1653,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2985,7 +3105,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 		pinmux = <STM32_PINMUX('O', 0, AF9)>;

--- a/dts/st/h7/stm32h7r3z8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r3z8tx-pinctrl.dtsi
@@ -1549,6 +1549,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1639,6 +1723,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3086,7 +3206,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 		pinmux = <STM32_PINMUX('O', 0, AF9)>;

--- a/dts/st/h7/stm32h7r7a8ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7a8ix-pinctrl.dtsi
@@ -1786,6 +1786,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1876,6 +1960,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3552,7 +3672,7 @@
 		pinmux = <STM32_PINMUX('M', 14, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/h7/stm32h7r7i8kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7i8kx-pinctrl.dtsi
@@ -1905,6 +1905,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1995,6 +2079,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3692,7 +3812,7 @@
 		pinmux = <STM32_PINMUX('M', 14, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/h7/stm32h7r7i8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7i8tx-pinctrl.dtsi
@@ -1828,6 +1828,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1918,6 +2002,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3585,7 +3705,7 @@
 		pinmux = <STM32_PINMUX('M', 14, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/h7/stm32h7r7l8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7l8hx-pinctrl.dtsi
@@ -2299,6 +2299,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2397,6 +2493,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4418,7 +4558,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/h7/stm32h7r7l8hxh-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7l8hxh-pinctrl.dtsi
@@ -2155,6 +2155,98 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2245,6 +2337,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4174,7 +4310,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/h7/stm32h7r7z8jx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7r7z8jx-pinctrl.dtsi
@@ -1476,6 +1476,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1566,6 +1646,38 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2842,7 +2954,7 @@
 		pinmux = <STM32_PINMUX('M', 14, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/h7/stm32h7s3a8ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3a8ix-pinctrl.dtsi
@@ -1781,6 +1781,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1871,6 +1955,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3502,7 +3622,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 		pinmux = <STM32_PINMUX('O', 0, AF9)>;

--- a/dts/st/h7/stm32h7s3i8kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3i8kx-pinctrl.dtsi
@@ -1889,6 +1889,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1979,6 +2063,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3657,7 +3777,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 		pinmux = <STM32_PINMUX('O', 0, AF9)>;

--- a/dts/st/h7/stm32h7s3i8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3i8tx-pinctrl.dtsi
@@ -1848,6 +1848,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1938,6 +2022,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3591,7 +3711,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 		pinmux = <STM32_PINMUX('O', 0, AF9)>;

--- a/dts/st/h7/stm32h7s3l8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3l8hx-pinctrl.dtsi
@@ -2299,6 +2299,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2397,6 +2493,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4220,7 +4360,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/h7/stm32h7s3l8hxh-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3l8hxh-pinctrl.dtsi
@@ -2155,6 +2155,98 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2245,6 +2337,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3992,7 +4128,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/h7/stm32h7s3r8vx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3r8vx-pinctrl.dtsi
@@ -555,6 +555,46 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1273,7 +1313,7 @@
 		pinmux = <STM32_PINMUX('M', 14, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 		pinmux = <STM32_PINMUX('O', 0, AF9)>;

--- a/dts/st/h7/stm32h7s3v8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3v8hx-pinctrl.dtsi
@@ -702,6 +702,66 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -792,6 +852,10 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1587,7 +1651,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 		pinmux = <STM32_PINMUX('O', 0, AF9)>;

--- a/dts/st/h7/stm32h7s3v8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3v8tx-pinctrl.dtsi
@@ -743,6 +743,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -833,6 +901,14 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1743,7 +1819,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 		pinmux = <STM32_PINMUX('O', 0, AF9)>;

--- a/dts/st/h7/stm32h7s3v8yx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3v8yx-pinctrl.dtsi
@@ -702,6 +702,74 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -783,6 +851,10 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1565,7 +1637,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 		pinmux = <STM32_PINMUX('O', 0, AF9)>;

--- a/dts/st/h7/stm32h7s3z8jx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3z8jx-pinctrl.dtsi
@@ -1479,6 +1479,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1569,6 +1653,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2985,7 +3105,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 		pinmux = <STM32_PINMUX('O', 0, AF9)>;

--- a/dts/st/h7/stm32h7s3z8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s3z8tx-pinctrl.dtsi
@@ -1549,6 +1549,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1639,6 +1723,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3086,7 +3206,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p1_ncs1_po0: xspim_p1_ncs1_po0 {
 		pinmux = <STM32_PINMUX('O', 0, AF9)>;

--- a/dts/st/h7/stm32h7s7a8ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7a8ix-pinctrl.dtsi
@@ -1786,6 +1786,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1876,6 +1960,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3552,7 +3672,7 @@
 		pinmux = <STM32_PINMUX('M', 14, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/h7/stm32h7s7i8kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7i8kx-pinctrl.dtsi
@@ -1905,6 +1905,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1995,6 +2079,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3692,7 +3812,7 @@
 		pinmux = <STM32_PINMUX('M', 14, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/h7/stm32h7s7i8tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7i8tx-pinctrl.dtsi
@@ -1828,6 +1828,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1918,6 +2002,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3585,7 +3705,7 @@
 		pinmux = <STM32_PINMUX('M', 14, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/h7/stm32h7s7l8hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7l8hx-pinctrl.dtsi
@@ -2299,6 +2299,102 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pg9: i2s1_sdi_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2397,6 +2493,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4418,7 +4558,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/h7/stm32h7s7l8hxh-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7l8hxh-pinctrl.dtsi
@@ -2155,6 +2155,98 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pg12: i2s6_sdi_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2245,6 +2337,50 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4174,7 +4310,7 @@
 		pinmux = <STM32_PINMUX('M', 9, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/h7/stm32h7s7z8jx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7s7z8jx-pinctrl.dtsi
@@ -1476,6 +1476,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pd7: i2s1_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1566,6 +1646,38 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2842,7 +2954,7 @@
 		pinmux = <STM32_PINMUX('M', 14, AF10)>;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/l1/stm32l151qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qchx-pinctrl.dtsi
@@ -844,6 +844,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l151qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qdhx-pinctrl.dtsi
@@ -844,6 +844,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l151qehx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qehx-pinctrl.dtsi
@@ -844,6 +844,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l151v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)hx-pinctrl.dtsi
@@ -634,6 +634,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l151v(8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)hxa-pinctrl.dtsi
@@ -634,6 +634,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l151v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)tx-pinctrl.dtsi
@@ -634,6 +634,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l151v(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)txa-pinctrl.dtsi
@@ -634,6 +634,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l151vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vchx-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l151vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vctx-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l151vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vctxa-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l151vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdtx-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l151vdtxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdtxx-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l151vdyxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdyxx-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l151vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vetx-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l151veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151veyx-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l151zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zctx-pinctrl.dtsi
@@ -876,6 +876,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l151zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zdtx-pinctrl.dtsi
@@ -876,6 +876,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l151zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zetx-pinctrl.dtsi
@@ -876,6 +876,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qchx-pinctrl.dtsi
@@ -844,6 +844,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qdhx-pinctrl.dtsi
@@ -844,6 +844,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152qehx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qehx-pinctrl.dtsi
@@ -844,6 +844,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)hx-pinctrl.dtsi
@@ -634,6 +634,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l152v(8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)hxa-pinctrl.dtsi
@@ -634,6 +634,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l152v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)tx-pinctrl.dtsi
@@ -634,6 +634,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l152v(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)txa-pinctrl.dtsi
@@ -634,6 +634,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l152vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vchx-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vctx-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vctxa-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vdtx-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152vdtxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vdtxx-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vetx-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152veyx-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zctx-pinctrl.dtsi
@@ -876,6 +876,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zdtx-pinctrl.dtsi
@@ -876,6 +876,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zetx-pinctrl.dtsi
@@ -876,6 +876,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162qchx-pinctrl.dtsi
@@ -844,6 +844,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162qdhx-pinctrl.dtsi
@@ -844,6 +844,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vchx-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vctx-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vctxa-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vdtx-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162vdyxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vdyxx-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vetx-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162veyx-pinctrl.dtsi
@@ -712,6 +712,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zctx-pinctrl.dtsi
@@ -876,6 +876,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zdtx-pinctrl.dtsi
@@ -876,6 +876,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zetx-pinctrl.dtsi
@@ -876,6 +876,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l4/stm32l412c8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412c8tx-pinctrl.dtsi
@@ -401,12 +401,32 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l412c8ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412c8ux-pinctrl.dtsi
@@ -401,12 +401,32 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l412cbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbtx-pinctrl.dtsi
@@ -401,12 +401,32 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l412cbtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbtxp-pinctrl.dtsi
@@ -381,12 +381,32 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l412cbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbux-pinctrl.dtsi
@@ -401,12 +401,32 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l412cbuxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbuxp-pinctrl.dtsi
@@ -381,12 +381,32 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l412k8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412k8tx-pinctrl.dtsi
@@ -299,12 +299,32 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l412k8ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412k8ux-pinctrl.dtsi
@@ -299,12 +299,32 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l412kbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412kbtx-pinctrl.dtsi
@@ -299,12 +299,32 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l412kbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412kbux-pinctrl.dtsi
@@ -299,12 +299,32 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l412r8ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412r8ix-pinctrl.dtsi
@@ -525,12 +525,52 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pc0: sys_traceclk_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l412r8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412r8tx-pinctrl.dtsi
@@ -525,12 +525,52 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pc0: sys_traceclk_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l412rbix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbix-pinctrl.dtsi
@@ -525,12 +525,52 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pc0: sys_traceclk_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l412rbixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbixp-pinctrl.dtsi
@@ -505,12 +505,48 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pc0: sys_traceclk_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l412rbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbtx-pinctrl.dtsi
@@ -525,12 +525,52 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pc0: sys_traceclk_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l412rbtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbtxp-pinctrl.dtsi
@@ -505,12 +505,48 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pc0: sys_traceclk_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l412t8yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412t8yx-pinctrl.dtsi
@@ -330,12 +330,32 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l412tbyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412tbyx-pinctrl.dtsi
@@ -330,12 +330,32 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l412tbyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412tbyxp-pinctrl.dtsi
@@ -320,12 +320,32 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l422cbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422cbtx-pinctrl.dtsi
@@ -401,12 +401,32 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l422cbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422cbux-pinctrl.dtsi
@@ -401,12 +401,32 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l422kbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422kbtx-pinctrl.dtsi
@@ -299,12 +299,32 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l422kbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422kbux-pinctrl.dtsi
@@ -299,12 +299,32 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l422rbix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422rbix-pinctrl.dtsi
@@ -525,12 +525,52 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pc0: sys_traceclk_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l422rbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422rbtx-pinctrl.dtsi
@@ -525,12 +525,52 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pc0: sys_traceclk_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l422tbyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422tbyx-pinctrl.dtsi
@@ -330,12 +330,32 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pb0: sys_traced0_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pb1: sys_traced1_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF0)>;
+	};
+
 	/omit-if-no-ref/ sys_jtdo_swo_pb3: sys_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ sys_jtrst_pb4: sys_jtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pb5: sys_traced2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pb6: sys_traced3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pb7: sys_traceclk_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l431vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431vcix-pinctrl.dtsi
@@ -690,6 +690,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l431vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431vctx-pinctrl.dtsi
@@ -690,6 +690,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l433vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vcix-pinctrl.dtsi
@@ -690,6 +690,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l433vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vctx-pinctrl.dtsi
@@ -690,6 +690,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l443vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vcix-pinctrl.dtsi
@@ -690,6 +690,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l443vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vctx-pinctrl.dtsi
@@ -690,6 +690,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l451r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)ix-pinctrl.dtsi
@@ -684,6 +684,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l451r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)tx-pinctrl.dtsi
@@ -684,6 +684,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l451r(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)yx-pinctrl.dtsi
@@ -684,6 +684,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l451v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451v(c-e)ix-pinctrl.dtsi
@@ -879,6 +879,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l451v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451v(c-e)tx-pinctrl.dtsi
@@ -879,6 +879,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
@@ -684,6 +684,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
@@ -684,6 +684,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
@@ -684,6 +684,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l452retxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452retxp-pinctrl.dtsi
@@ -668,6 +668,18 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l452reyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452reyxp-pinctrl.dtsi
@@ -684,6 +684,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
@@ -879,6 +879,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
@@ -879,6 +879,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l462reix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reix-pinctrl.dtsi
@@ -684,6 +684,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l462retx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462retx-pinctrl.dtsi
@@ -684,6 +684,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l462reyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reyx-pinctrl.dtsi
@@ -684,6 +684,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l462veix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462veix-pinctrl.dtsi
@@ -879,6 +879,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l462vetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462vetx-pinctrl.dtsi
@@ -879,6 +879,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
@@ -1355,6 +1355,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
@@ -1048,6 +1048,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
@@ -1395,6 +1395,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
@@ -1395,6 +1395,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
@@ -1048,6 +1048,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
@@ -1355,6 +1355,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l476qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476qgixp-pinctrl.dtsi
@@ -1355,6 +1355,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
@@ -1048,6 +1048,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
@@ -1395,6 +1395,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
@@ -1395,6 +1395,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
@@ -1367,6 +1367,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l486qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486qgix-pinctrl.dtsi
@@ -1355,6 +1355,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
@@ -1048,6 +1048,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
@@ -1395,6 +1395,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
@@ -1890,6 +1890,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496agixp-pinctrl.dtsi
@@ -1867,6 +1867,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
@@ -1639,6 +1639,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
@@ -1598,6 +1598,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496qgixs-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixs-pinctrl.dtsi
@@ -1639,6 +1639,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
@@ -817,6 +817,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
@@ -792,6 +792,18 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
@@ -1293,6 +1293,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
@@ -1253,6 +1253,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
@@ -1206,6 +1206,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
@@ -1190,6 +1190,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
@@ -1317,6 +1317,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
@@ -1684,6 +1684,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
@@ -1645,6 +1645,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
@@ -1890,6 +1890,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
@@ -1867,6 +1867,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
@@ -1639,6 +1639,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
@@ -1598,6 +1598,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
@@ -817,6 +817,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
@@ -792,6 +792,18 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
@@ -1293,6 +1293,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
@@ -1253,6 +1253,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
@@ -1206,6 +1206,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
@@ -1190,6 +1190,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
@@ -1684,6 +1684,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
@@ -1645,6 +1645,42 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
@@ -1779,6 +1779,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
@@ -1756,6 +1756,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
@@ -1527,6 +1527,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
@@ -1491,6 +1491,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4p5qgixs-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5qgixs-pinctrl.dtsi
@@ -1491,6 +1491,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
@@ -746,6 +746,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
@@ -721,6 +721,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
@@ -1198,6 +1198,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
@@ -1129,6 +1129,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
@@ -1163,6 +1163,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
@@ -1113,6 +1113,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
@@ -1557,6 +1557,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
@@ -1523,6 +1523,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
@@ -1779,6 +1779,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4q5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agixp-pinctrl.dtsi
@@ -1756,6 +1756,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
@@ -1527,6 +1527,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4q5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgixp-pinctrl.dtsi
@@ -1491,6 +1491,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
@@ -746,6 +746,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4q5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtxp-pinctrl.dtsi
@@ -721,6 +721,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
@@ -1198,6 +1198,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4q5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtxp-pinctrl.dtsi
@@ -1163,6 +1163,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
@@ -1129,6 +1129,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4q5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyxp-pinctrl.dtsi
@@ -1113,6 +1113,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
@@ -1557,6 +1557,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4q5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtxp-pinctrl.dtsi
@@ -1523,6 +1523,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
@@ -1790,6 +1790,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4r5aiixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5aiixp-pinctrl.dtsi
@@ -1790,6 +1790,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
@@ -1538,6 +1538,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4r5qgixs-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5qgixs-pinctrl.dtsi
@@ -1538,6 +1538,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4r5qiixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5qiixp-pinctrl.dtsi
@@ -1538,6 +1538,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
@@ -1199,6 +1199,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
@@ -1568,6 +1568,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
@@ -1526,6 +1526,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
@@ -1529,6 +1529,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
@@ -1790,6 +1790,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
@@ -1199,6 +1199,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
@@ -1568,6 +1568,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
@@ -1724,6 +1724,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
@@ -1092,6 +1092,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
@@ -1534,6 +1534,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
@@ -1516,6 +1516,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
@@ -1526,6 +1526,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
@@ -1485,6 +1485,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
@@ -1790,6 +1790,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
@@ -1538,6 +1538,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
@@ -1199,6 +1199,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
@@ -1568,6 +1568,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
@@ -1526,6 +1526,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
@@ -1790,6 +1790,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
@@ -1199,6 +1199,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
@@ -1568,6 +1568,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
@@ -1724,6 +1724,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
@@ -1092,6 +1092,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
@@ -1534,6 +1534,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
@@ -1516,6 +1516,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
@@ -1526,6 +1526,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced0_pc1: sys_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pc9: sys_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pe3: sys_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced1_pe4: sys_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pe5: sys_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pe6: sys_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
@@ -681,6 +681,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
@@ -669,6 +669,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
@@ -1320,6 +1320,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l552qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeix-pinctrl.dtsi
@@ -1365,6 +1365,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
@@ -1352,6 +1352,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
@@ -640,6 +640,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l552retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxp-pinctrl.dtsi
@@ -620,6 +620,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l552retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxq-pinctrl.dtsi
@@ -560,6 +560,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
@@ -990,6 +990,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l552vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552vetx-pinctrl.dtsi
@@ -1046,6 +1046,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
@@ -1340,6 +1340,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l552zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552zetx-pinctrl.dtsi
@@ -1390,6 +1390,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
@@ -681,6 +681,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
@@ -669,6 +669,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l562qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeix-pinctrl.dtsi
@@ -1365,6 +1365,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
@@ -1352,6 +1352,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
@@ -1320,6 +1320,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l562retx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retx-pinctrl.dtsi
@@ -640,6 +640,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l562retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxp-pinctrl.dtsi
@@ -620,6 +620,22 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l562retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxq-pinctrl.dtsi
@@ -560,6 +560,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l562vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetx-pinctrl.dtsi
@@ -1046,6 +1046,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
@@ -990,6 +990,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l562zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetx-pinctrl.dtsi
@@ -1390,6 +1390,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
@@ -1340,6 +1340,46 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
@@ -2572,6 +2572,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2616,6 +2704,164 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi12: debug_traced0_pi12 {
+		pinmux = <STM32_PINMUX('I', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi13: debug_traced1_pi13 {
+		pinmux = <STM32_PINMUX('I', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pi14: debug_traceclk_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pj0: debug_traced8_pj0 {
+		pinmux = <STM32_PINMUX('J', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pj1: debug_traced9_pj1 {
+		pinmux = <STM32_PINMUX('J', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pj5: debug_traced2_pj5 {
+		pinmux = <STM32_PINMUX('J', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pj6: debug_traced3_pj6 {
+		pinmux = <STM32_PINMUX('J', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pk1: debug_traced4_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pk2: debug_traced5_pk2 {
+		pinmux = <STM32_PINMUX('K', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pk5: debug_traced6_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pk6: debug_traced7_pk6 {
+		pinmux = <STM32_PINMUX('K', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
@@ -1701,6 +1701,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1737,6 +1809,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
@@ -2460,6 +2460,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2504,6 +2592,120 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
@@ -1701,6 +1701,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1737,6 +1809,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
@@ -2572,6 +2572,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2616,6 +2704,164 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi12: debug_traced0_pi12 {
+		pinmux = <STM32_PINMUX('I', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi13: debug_traced1_pi13 {
+		pinmux = <STM32_PINMUX('I', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pi14: debug_traceclk_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pj0: debug_traced8_pj0 {
+		pinmux = <STM32_PINMUX('J', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pj1: debug_traced9_pj1 {
+		pinmux = <STM32_PINMUX('J', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pj5: debug_traced2_pj5 {
+		pinmux = <STM32_PINMUX('J', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pj6: debug_traced3_pj6 {
+		pinmux = <STM32_PINMUX('J', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pk1: debug_traced4_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pk2: debug_traced5_pk2 {
+		pinmux = <STM32_PINMUX('K', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pk5: debug_traced6_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pk6: debug_traced7_pk6 {
+		pinmux = <STM32_PINMUX('K', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
@@ -1701,6 +1701,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1737,6 +1809,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
@@ -2460,6 +2460,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2504,6 +2592,120 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
@@ -1701,6 +1701,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1737,6 +1809,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
@@ -2572,6 +2572,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2616,6 +2704,164 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi12: debug_traced0_pi12 {
+		pinmux = <STM32_PINMUX('I', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi13: debug_traced1_pi13 {
+		pinmux = <STM32_PINMUX('I', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pi14: debug_traceclk_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pj0: debug_traced8_pj0 {
+		pinmux = <STM32_PINMUX('J', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pj1: debug_traced9_pj1 {
+		pinmux = <STM32_PINMUX('J', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pj5: debug_traced2_pj5 {
+		pinmux = <STM32_PINMUX('J', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pj6: debug_traced3_pj6 {
+		pinmux = <STM32_PINMUX('J', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pk1: debug_traced4_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pk2: debug_traced5_pk2 {
+		pinmux = <STM32_PINMUX('K', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pk5: debug_traced6_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pk6: debug_traced7_pk6 {
+		pinmux = <STM32_PINMUX('K', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
@@ -1701,6 +1701,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1737,6 +1809,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
@@ -2460,6 +2460,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2504,6 +2592,120 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
@@ -1701,6 +1701,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1737,6 +1809,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
@@ -2572,6 +2572,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2616,6 +2704,164 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi12: debug_traced0_pi12 {
+		pinmux = <STM32_PINMUX('I', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi13: debug_traced1_pi13 {
+		pinmux = <STM32_PINMUX('I', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pi14: debug_traceclk_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pj0: debug_traced8_pj0 {
+		pinmux = <STM32_PINMUX('J', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pj1: debug_traced9_pj1 {
+		pinmux = <STM32_PINMUX('J', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pj5: debug_traced2_pj5 {
+		pinmux = <STM32_PINMUX('J', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pj6: debug_traced3_pj6 {
+		pinmux = <STM32_PINMUX('J', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pk1: debug_traced4_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pk2: debug_traced5_pk2 {
+		pinmux = <STM32_PINMUX('K', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pk5: debug_traced6_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pk6: debug_traced7_pk6 {
+		pinmux = <STM32_PINMUX('K', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
@@ -1701,6 +1701,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1737,6 +1809,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
@@ -2460,6 +2460,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2504,6 +2592,120 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
@@ -1701,6 +1701,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1737,6 +1809,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
@@ -2628,6 +2628,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2672,6 +2760,164 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi12: debug_traced0_pi12 {
+		pinmux = <STM32_PINMUX('I', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi13: debug_traced1_pi13 {
+		pinmux = <STM32_PINMUX('I', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pi14: debug_traceclk_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pj0: debug_traced8_pj0 {
+		pinmux = <STM32_PINMUX('J', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pj1: debug_traced9_pj1 {
+		pinmux = <STM32_PINMUX('J', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pj5: debug_traced2_pj5 {
+		pinmux = <STM32_PINMUX('J', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pj6: debug_traced3_pj6 {
+		pinmux = <STM32_PINMUX('J', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pk1: debug_traced4_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pk2: debug_traced5_pk2 {
+		pinmux = <STM32_PINMUX('K', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pk5: debug_traced6_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pk6: debug_traced7_pk6 {
+		pinmux = <STM32_PINMUX('K', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
@@ -1745,6 +1745,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1781,6 +1853,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
@@ -2516,6 +2516,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2560,6 +2648,120 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
@@ -1745,6 +1745,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1781,6 +1853,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
@@ -2628,6 +2628,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2672,6 +2760,164 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi12: debug_traced0_pi12 {
+		pinmux = <STM32_PINMUX('I', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi13: debug_traced1_pi13 {
+		pinmux = <STM32_PINMUX('I', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pi14: debug_traceclk_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pj0: debug_traced8_pj0 {
+		pinmux = <STM32_PINMUX('J', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pj1: debug_traced9_pj1 {
+		pinmux = <STM32_PINMUX('J', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pj5: debug_traced2_pj5 {
+		pinmux = <STM32_PINMUX('J', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pj6: debug_traced3_pj6 {
+		pinmux = <STM32_PINMUX('J', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pk1: debug_traced4_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pk2: debug_traced5_pk2 {
+		pinmux = <STM32_PINMUX('K', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pk5: debug_traced6_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pk6: debug_traced7_pk6 {
+		pinmux = <STM32_PINMUX('K', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
@@ -1745,6 +1745,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1781,6 +1853,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
@@ -2516,6 +2516,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2560,6 +2648,120 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
@@ -1745,6 +1745,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1781,6 +1853,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
@@ -2628,6 +2628,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2672,6 +2760,164 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi12: debug_traced0_pi12 {
+		pinmux = <STM32_PINMUX('I', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi13: debug_traced1_pi13 {
+		pinmux = <STM32_PINMUX('I', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pi14: debug_traceclk_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pj0: debug_traced8_pj0 {
+		pinmux = <STM32_PINMUX('J', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pj1: debug_traced9_pj1 {
+		pinmux = <STM32_PINMUX('J', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pj5: debug_traced2_pj5 {
+		pinmux = <STM32_PINMUX('J', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pj6: debug_traced3_pj6 {
+		pinmux = <STM32_PINMUX('J', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pk1: debug_traced4_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pk2: debug_traced5_pk2 {
+		pinmux = <STM32_PINMUX('K', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pk5: debug_traced6_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pk6: debug_traced7_pk6 {
+		pinmux = <STM32_PINMUX('K', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
@@ -1745,6 +1745,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1781,6 +1853,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
@@ -2516,6 +2516,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2560,6 +2648,120 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
@@ -1745,6 +1745,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1781,6 +1853,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
@@ -2628,6 +2628,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2672,6 +2760,164 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi12: debug_traced0_pi12 {
+		pinmux = <STM32_PINMUX('I', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi13: debug_traced1_pi13 {
+		pinmux = <STM32_PINMUX('I', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pi14: debug_traceclk_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pj0: debug_traced8_pj0 {
+		pinmux = <STM32_PINMUX('J', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pj1: debug_traced9_pj1 {
+		pinmux = <STM32_PINMUX('J', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pj5: debug_traced2_pj5 {
+		pinmux = <STM32_PINMUX('J', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pj6: debug_traced3_pj6 {
+		pinmux = <STM32_PINMUX('J', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pk1: debug_traced4_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pk2: debug_traced5_pk2 {
+		pinmux = <STM32_PINMUX('K', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pk5: debug_traced6_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pk6: debug_traced7_pk6 {
+		pinmux = <STM32_PINMUX('K', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
@@ -1745,6 +1745,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1781,6 +1853,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
@@ -2516,6 +2516,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2560,6 +2648,120 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
@@ -1745,6 +1745,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1781,6 +1853,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
@@ -2628,6 +2628,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2672,6 +2760,164 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi12: debug_traced0_pi12 {
+		pinmux = <STM32_PINMUX('I', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi13: debug_traced1_pi13 {
+		pinmux = <STM32_PINMUX('I', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pi14: debug_traceclk_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pj0: debug_traced8_pj0 {
+		pinmux = <STM32_PINMUX('J', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pj1: debug_traced9_pj1 {
+		pinmux = <STM32_PINMUX('J', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pj5: debug_traced2_pj5 {
+		pinmux = <STM32_PINMUX('J', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pj6: debug_traced3_pj6 {
+		pinmux = <STM32_PINMUX('J', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pk1: debug_traced4_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pk2: debug_traced5_pk2 {
+		pinmux = <STM32_PINMUX('K', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pk5: debug_traced6_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pk6: debug_traced7_pk6 {
+		pinmux = <STM32_PINMUX('K', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
@@ -1745,6 +1745,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1781,6 +1853,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
@@ -2516,6 +2516,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2560,6 +2648,120 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
@@ -1745,6 +1745,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1781,6 +1853,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
@@ -2628,6 +2628,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2672,6 +2760,164 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi12: debug_traced0_pi12 {
+		pinmux = <STM32_PINMUX('I', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi13: debug_traced1_pi13 {
+		pinmux = <STM32_PINMUX('I', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pi14: debug_traceclk_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pj0: debug_traced8_pj0 {
+		pinmux = <STM32_PINMUX('J', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pj1: debug_traced9_pj1 {
+		pinmux = <STM32_PINMUX('J', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pj5: debug_traced2_pj5 {
+		pinmux = <STM32_PINMUX('J', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pj6: debug_traced3_pj6 {
+		pinmux = <STM32_PINMUX('J', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pk1: debug_traced4_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pk2: debug_traced5_pk2 {
+		pinmux = <STM32_PINMUX('K', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pk5: debug_traced6_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pk6: debug_traced7_pk6 {
+		pinmux = <STM32_PINMUX('K', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
@@ -1745,6 +1745,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1781,6 +1853,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
@@ -2516,6 +2516,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2560,6 +2648,120 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
@@ -1745,6 +1745,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1781,6 +1853,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
@@ -2628,6 +2628,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2672,6 +2760,164 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi12: debug_traced0_pi12 {
+		pinmux = <STM32_PINMUX('I', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi13: debug_traced1_pi13 {
+		pinmux = <STM32_PINMUX('I', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pi14: debug_traceclk_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pj0: debug_traced8_pj0 {
+		pinmux = <STM32_PINMUX('J', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pj1: debug_traced9_pj1 {
+		pinmux = <STM32_PINMUX('J', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pj5: debug_traced2_pj5 {
+		pinmux = <STM32_PINMUX('J', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pj6: debug_traced3_pj6 {
+		pinmux = <STM32_PINMUX('J', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pk1: debug_traced4_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pk2: debug_traced5_pk2 {
+		pinmux = <STM32_PINMUX('K', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pk5: debug_traced6_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pk6: debug_traced7_pk6 {
+		pinmux = <STM32_PINMUX('K', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
@@ -1745,6 +1745,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1781,6 +1853,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
@@ -2516,6 +2516,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2560,6 +2648,120 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
@@ -1745,6 +1745,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1781,6 +1853,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
@@ -2628,6 +2628,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2672,6 +2760,164 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pi12: debug_traced0_pi12 {
+		pinmux = <STM32_PINMUX('I', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pi13: debug_traced1_pi13 {
+		pinmux = <STM32_PINMUX('I', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pi14: debug_traceclk_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pj0: debug_traced8_pj0 {
+		pinmux = <STM32_PINMUX('J', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pj1: debug_traced9_pj1 {
+		pinmux = <STM32_PINMUX('J', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pj5: debug_traced2_pj5 {
+		pinmux = <STM32_PINMUX('J', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pj6: debug_traced3_pj6 {
+		pinmux = <STM32_PINMUX('J', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pk1: debug_traced4_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pk2: debug_traced5_pk2 {
+		pinmux = <STM32_PINMUX('K', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pk5: debug_traced6_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pk6: debug_traced7_pk6 {
+		pinmux = <STM32_PINMUX('K', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
@@ -1745,6 +1745,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1781,6 +1853,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
@@ -2516,6 +2516,94 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pz1: i2s1_sdi_pz1 {
+		pinmux = <STM32_PINMUX('Z', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pi2: i2s2_sdi_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pz2: i2s1_sdo_pz2 {
+		pinmux = <STM32_PINMUX('Z', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi3: i2s2_sdo_pi3 {
+		pinmux = <STM32_PINMUX('I', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2560,6 +2648,120 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pf12: debug_traced4_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pf13: debug_traced5_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pf14: debug_traced6_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf15: debug_traced7_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg0: debug_traced0_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg1: debug_traced1_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pg2: debug_traced2_pg2 {
+		pinmux = <STM32_PINMUX('G', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg3: debug_traced3_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
@@ -1745,6 +1745,78 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb14: i2s2_sdi_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc2: i2s2_sdi_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd10: i2s3_sdi_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb15: i2s2_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc1: i2s2_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pc3: i2s2_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pa8: i2s3_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pd6: i2s3_sdo_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1781,6 +1853,88 @@
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traced4_pb2: debug_traced4_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pb3: debug_traced9_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pb4: debug_traced8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc3: debug_traceclk_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd7: debug_traced6_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe5: debug_traced3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe6: debug_traced2_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg15: debug_traced7_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp131aaex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131aaex-pinctrl.dtsi
@@ -1691,6 +1691,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1747,6 +1827,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -1755,12 +1911,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp131aafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131aafx-pinctrl.dtsi
@@ -1691,6 +1691,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1747,6 +1827,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -1755,12 +1911,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp131aagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131aagx-pinctrl.dtsi
@@ -1691,6 +1691,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1747,6 +1827,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -1755,12 +1911,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp131caex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131caex-pinctrl.dtsi
@@ -1691,6 +1691,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1747,6 +1827,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -1755,12 +1911,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp131cafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131cafx-pinctrl.dtsi
@@ -1691,6 +1691,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1747,6 +1827,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -1755,12 +1911,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp131cagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131cagx-pinctrl.dtsi
@@ -1691,6 +1691,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1747,6 +1827,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -1755,12 +1911,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp131daex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131daex-pinctrl.dtsi
@@ -1691,6 +1691,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1747,6 +1827,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -1755,12 +1911,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp131dafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131dafx-pinctrl.dtsi
@@ -1691,6 +1691,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1747,6 +1827,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -1755,12 +1911,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp131dagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131dagx-pinctrl.dtsi
@@ -1691,6 +1691,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1747,6 +1827,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -1755,12 +1911,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp131faex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131faex-pinctrl.dtsi
@@ -1691,6 +1691,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1747,6 +1827,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -1755,12 +1911,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp131fafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131fafx-pinctrl.dtsi
@@ -1691,6 +1691,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1747,6 +1827,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -1755,12 +1911,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp131fagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp131fagx-pinctrl.dtsi
@@ -1691,6 +1691,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -1747,6 +1827,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -1755,12 +1911,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp133aaex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133aaex-pinctrl.dtsi
@@ -2040,6 +2040,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2096,6 +2176,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2104,12 +2260,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp133aafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133aafx-pinctrl.dtsi
@@ -2040,6 +2040,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2096,6 +2176,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2104,12 +2260,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp133aagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133aagx-pinctrl.dtsi
@@ -2040,6 +2040,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2096,6 +2176,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2104,12 +2260,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp133caex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133caex-pinctrl.dtsi
@@ -2040,6 +2040,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2096,6 +2176,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2104,12 +2260,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp133cafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133cafx-pinctrl.dtsi
@@ -2040,6 +2040,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2096,6 +2176,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2104,12 +2260,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp133cagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133cagx-pinctrl.dtsi
@@ -2040,6 +2040,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2096,6 +2176,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2104,12 +2260,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp133daex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133daex-pinctrl.dtsi
@@ -2040,6 +2040,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2096,6 +2176,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2104,12 +2260,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp133dafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133dafx-pinctrl.dtsi
@@ -2040,6 +2040,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2096,6 +2176,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2104,12 +2260,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp133dagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133dagx-pinctrl.dtsi
@@ -2040,6 +2040,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2096,6 +2176,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2104,12 +2260,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp133faex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133faex-pinctrl.dtsi
@@ -2040,6 +2040,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2096,6 +2176,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2104,12 +2260,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp133fafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133fafx-pinctrl.dtsi
@@ -2040,6 +2040,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2096,6 +2176,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2104,12 +2260,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp133fagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp133fagx-pinctrl.dtsi
@@ -2040,6 +2040,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2096,6 +2176,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2104,12 +2260,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp135aaex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135aaex-pinctrl.dtsi
@@ -2327,6 +2327,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2383,6 +2463,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2391,12 +2547,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp135aafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135aafx-pinctrl.dtsi
@@ -2327,6 +2327,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2383,6 +2463,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2391,12 +2547,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp135aagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135aagx-pinctrl.dtsi
@@ -2327,6 +2327,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2383,6 +2463,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2391,12 +2547,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp135caex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135caex-pinctrl.dtsi
@@ -2327,6 +2327,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2383,6 +2463,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2391,12 +2547,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp135cafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135cafx-pinctrl.dtsi
@@ -2327,6 +2327,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2383,6 +2463,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2391,12 +2547,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp135cagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135cagx-pinctrl.dtsi
@@ -2327,6 +2327,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2383,6 +2463,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2391,12 +2547,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp135daex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135daex-pinctrl.dtsi
@@ -2327,6 +2327,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2383,6 +2463,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2391,12 +2547,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp135dafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135dafx-pinctrl.dtsi
@@ -2327,6 +2327,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2383,6 +2463,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2391,12 +2547,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp135dagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135dagx-pinctrl.dtsi
@@ -2327,6 +2327,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2383,6 +2463,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2391,12 +2547,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp135faex-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135faex-pinctrl.dtsi
@@ -2327,6 +2327,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2383,6 +2463,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2391,12 +2547,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp135fafx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135fafx-pinctrl.dtsi
@@ -2327,6 +2327,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2383,6 +2463,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2391,12 +2547,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp13/stm32mp135fagx-pinctrl.dtsi
+++ b/dts/st/mp13/stm32mp135fagx-pinctrl.dtsi
@@ -2327,6 +2327,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pc3: i2s1_sdi_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb5: i2s2_sdi_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pg1: i2s2_sdi_pg1 {
+		pinmux = <STM32_PINMUX('G', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc8: i2s3_sdi_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pd4: i2s3_sdi_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pg7: i2s3_sdi_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe3: i2s4_sdi_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pe13: i2s4_sdi_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdi_pf3: i2s4_sdi_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa3: i2s1_sdo_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc0: i2s1_sdo_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pa8: i2s2_sdo_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_ph10: i2s2_sdo_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc11: i2s3_sdo_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pf1: i2s3_sdo_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pb15: i2s4_sdo_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pd1: i2s4_sdo_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s4_sdo_pe11: i2s4_sdo_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {
@@ -2383,6 +2463,82 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traced5_pa15: debug_traced5_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb3: debug_traced2_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pb5: debug_traced4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pb6: debug_traced6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb9: debug_traced3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb13: debug_traceclk_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb14: debug_traced0_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc6: debug_traced2_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pc7: debug_traced4_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc8: debug_traced0_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc9: debug_traced1_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pc10: debug_traced2_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc11: debug_traced3_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pc12: debug_traceclk_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd2: debug_traced4_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd9: debug_traceclk_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pf1: debug_traced7_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf2: debug_traced1_pf2 {
+		pinmux = <STM32_PINMUX('F', 2, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtck_swclk_pf14: debug_jtck_swclk_pf14 {
 		pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 	};
@@ -2391,12 +2547,32 @@
 		pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pg4: debug_traced1_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg6: debug_traced3_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg7: debug_traced8_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdi_ph4: debug_jtdi_ph4 {
 		pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_ph5: debug_jtdo_swo_ph5 {
 		pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_ph8: debug_traced9_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_ph10: debug_traced0_ph10 {
+		pinmux = <STM32_PINMUX('H', 10, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp211aalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211aalx-pinctrl.dtsi
@@ -2045,6 +2045,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2169,6 +2249,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp211aamx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211aamx-pinctrl.dtsi
@@ -2045,6 +2045,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2169,6 +2249,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp211aanx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211aanx-pinctrl.dtsi
@@ -2045,6 +2045,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2169,6 +2249,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp211aaox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211aaox-pinctrl.dtsi
@@ -1761,6 +1761,62 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -1852,6 +1908,88 @@
 	/omit-if-no-ref/ i3c3_sda_pg2: i3c3_sda_pg2 {
 		pinmux = <STM32_PINMUX('G', 2, AF3)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp211calx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211calx-pinctrl.dtsi
@@ -2045,6 +2045,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2169,6 +2249,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp211camx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211camx-pinctrl.dtsi
@@ -2045,6 +2045,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2169,6 +2249,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp211canx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211canx-pinctrl.dtsi
@@ -2045,6 +2045,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2169,6 +2249,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp211caox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211caox-pinctrl.dtsi
@@ -1761,6 +1761,62 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -1852,6 +1908,88 @@
 	/omit-if-no-ref/ i3c3_sda_pg2: i3c3_sda_pg2 {
 		pinmux = <STM32_PINMUX('G', 2, AF3)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp211dalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211dalx-pinctrl.dtsi
@@ -2045,6 +2045,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2169,6 +2249,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp211damx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211damx-pinctrl.dtsi
@@ -2045,6 +2045,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2169,6 +2249,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp211danx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211danx-pinctrl.dtsi
@@ -2045,6 +2045,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2169,6 +2249,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp211daox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211daox-pinctrl.dtsi
@@ -1761,6 +1761,62 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -1852,6 +1908,88 @@
 	/omit-if-no-ref/ i3c3_sda_pg2: i3c3_sda_pg2 {
 		pinmux = <STM32_PINMUX('G', 2, AF3)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp211falx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211falx-pinctrl.dtsi
@@ -2045,6 +2045,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2169,6 +2249,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp211famx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211famx-pinctrl.dtsi
@@ -2045,6 +2045,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2169,6 +2249,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp211fanx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211fanx-pinctrl.dtsi
@@ -2045,6 +2045,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2169,6 +2249,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp211faox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211faox-pinctrl.dtsi
@@ -1761,6 +1761,62 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -1852,6 +1908,88 @@
 	/omit-if-no-ref/ i3c3_sda_pg2: i3c3_sda_pg2 {
 		pinmux = <STM32_PINMUX('G', 2, AF3)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp213aalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213aalx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp213aamx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213aamx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp213aanx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213aanx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp213aaox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213aaox-pinctrl.dtsi
@@ -2104,6 +2104,62 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2195,6 +2251,88 @@
 	/omit-if-no-ref/ i3c3_sda_pg2: i3c3_sda_pg2 {
 		pinmux = <STM32_PINMUX('G', 2, AF3)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp213calx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213calx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp213camx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213camx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp213canx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213canx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp213caox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213caox-pinctrl.dtsi
@@ -2104,6 +2104,62 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2195,6 +2251,88 @@
 	/omit-if-no-ref/ i3c3_sda_pg2: i3c3_sda_pg2 {
 		pinmux = <STM32_PINMUX('G', 2, AF3)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp213dalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213dalx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp213damx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213damx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp213danx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213danx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp213daox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213daox-pinctrl.dtsi
@@ -2104,6 +2104,62 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2195,6 +2251,88 @@
 	/omit-if-no-ref/ i3c3_sda_pg2: i3c3_sda_pg2 {
 		pinmux = <STM32_PINMUX('G', 2, AF3)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp213falx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213falx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp213famx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213famx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp213fanx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213fanx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp213faox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213faox-pinctrl.dtsi
@@ -2104,6 +2104,62 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2195,6 +2251,88 @@
 	/omit-if-no-ref/ i3c3_sda_pg2: i3c3_sda_pg2 {
 		pinmux = <STM32_PINMUX('G', 2, AF3)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp215aalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215aalx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp215aamx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215aamx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp215aanx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215aanx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp215aaox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215aaox-pinctrl.dtsi
@@ -2104,6 +2104,62 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2195,6 +2251,88 @@
 	/omit-if-no-ref/ i3c3_sda_pg2: i3c3_sda_pg2 {
 		pinmux = <STM32_PINMUX('G', 2, AF3)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp215calx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215calx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp215camx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215camx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp215canx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215canx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp215caox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215caox-pinctrl.dtsi
@@ -2104,6 +2104,62 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2195,6 +2251,88 @@
 	/omit-if-no-ref/ i3c3_sda_pg2: i3c3_sda_pg2 {
 		pinmux = <STM32_PINMUX('G', 2, AF3)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp215dalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215dalx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp215damx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215damx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp215danx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215danx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp215daox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215daox-pinctrl.dtsi
@@ -2104,6 +2104,62 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2195,6 +2251,88 @@
 	/omit-if-no-ref/ i3c3_sda_pg2: i3c3_sda_pg2 {
 		pinmux = <STM32_PINMUX('G', 2, AF3)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp215falx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215falx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp215famx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215famx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp215fanx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215fanx-pinctrl.dtsi
@@ -2392,6 +2392,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2516,6 +2596,100 @@
 	/omit-if-no-ref/ i3c3_sda_pz3: i3c3_sda_pz3 {
 		pinmux = <STM32_PINMUX('Z', 3, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp215faox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215faox-pinctrl.dtsi
@@ -2104,6 +2104,62 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb13: i2s2_sdo_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2195,6 +2251,88 @@
 	/omit-if-no-ref/ i3c3_sda_pg2: i3c3_sda_pg2 {
 		pinmux = <STM32_PINMUX('G', 2, AF3)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp231aajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231aajx-pinctrl.dtsi
@@ -2219,6 +2219,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2337,6 +2421,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp231aakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231aakx-pinctrl.dtsi
@@ -2219,6 +2219,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2337,6 +2421,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp231aalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231aalx-pinctrl.dtsi
@@ -2219,6 +2219,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2337,6 +2421,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp231cajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231cajx-pinctrl.dtsi
@@ -2219,6 +2219,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2337,6 +2421,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp231cakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231cakx-pinctrl.dtsi
@@ -2219,6 +2219,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2337,6 +2421,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp231calx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231calx-pinctrl.dtsi
@@ -2219,6 +2219,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2337,6 +2421,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp231dajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231dajx-pinctrl.dtsi
@@ -2219,6 +2219,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2337,6 +2421,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp231dakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231dakx-pinctrl.dtsi
@@ -2219,6 +2219,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2337,6 +2421,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp231dalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231dalx-pinctrl.dtsi
@@ -2219,6 +2219,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2337,6 +2421,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp231fajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231fajx-pinctrl.dtsi
@@ -2219,6 +2219,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2337,6 +2421,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp231fakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231fakx-pinctrl.dtsi
@@ -2219,6 +2219,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2337,6 +2421,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp231falx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231falx-pinctrl.dtsi
@@ -2219,6 +2219,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2337,6 +2421,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp233aajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233aajx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp233aakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233aakx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp233aalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233aalx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp233cajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233cajx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp233cakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233cakx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp233calx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233calx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp233dajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233dajx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp233dakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233dakx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp233dalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233dalx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp233fajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233fajx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp233fakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233fakx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp233falx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233falx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp235aajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235aajx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp235aakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235aakx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp235aalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235aalx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp235cajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235cajx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp235cakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235cakx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp235calx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235calx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp235dajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235dajx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp235dakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235dakx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp235dalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235dalx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp235fajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235fajx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp235fakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235fakx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp235falx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235falx-pinctrl.dtsi
@@ -2574,6 +2574,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2692,6 +2776,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp251aaix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251aaix-pinctrl.dtsi
@@ -2894,6 +2894,98 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pk0: i2s2_sdi_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pk1: i2s2_sdo_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3066,6 +3158,112 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pj15: debug_traced7_pj15 {
+		pinmux = <STM32_PINMUX('J', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp251aajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251aajx-pinctrl.dtsi
@@ -2379,6 +2379,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2527,6 +2611,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp251aakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251aakx-pinctrl.dtsi
@@ -2379,6 +2379,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2527,6 +2611,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp251aalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251aalx-pinctrl.dtsi
@@ -2379,6 +2379,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2527,6 +2611,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp251caix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251caix-pinctrl.dtsi
@@ -2894,6 +2894,98 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pk0: i2s2_sdi_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pk1: i2s2_sdo_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3066,6 +3158,112 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pj15: debug_traced7_pj15 {
+		pinmux = <STM32_PINMUX('J', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp251cajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251cajx-pinctrl.dtsi
@@ -2379,6 +2379,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2527,6 +2611,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp251cakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251cakx-pinctrl.dtsi
@@ -2379,6 +2379,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2527,6 +2611,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp251calx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251calx-pinctrl.dtsi
@@ -2379,6 +2379,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2527,6 +2611,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp251daix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251daix-pinctrl.dtsi
@@ -2894,6 +2894,98 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pk0: i2s2_sdi_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pk1: i2s2_sdo_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3066,6 +3158,112 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pj15: debug_traced7_pj15 {
+		pinmux = <STM32_PINMUX('J', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp251dajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251dajx-pinctrl.dtsi
@@ -2379,6 +2379,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2527,6 +2611,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp251dakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251dakx-pinctrl.dtsi
@@ -2379,6 +2379,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2527,6 +2611,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp251dalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251dalx-pinctrl.dtsi
@@ -2379,6 +2379,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2527,6 +2611,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp251faix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251faix-pinctrl.dtsi
@@ -2894,6 +2894,98 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pk0: i2s2_sdi_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pk1: i2s2_sdo_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3066,6 +3158,112 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pj15: debug_traced7_pj15 {
+		pinmux = <STM32_PINMUX('J', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp251fajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251fajx-pinctrl.dtsi
@@ -2379,6 +2379,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2527,6 +2611,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp251fakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251fakx-pinctrl.dtsi
@@ -2379,6 +2379,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2527,6 +2611,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp251falx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251falx-pinctrl.dtsi
@@ -2379,6 +2379,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2527,6 +2611,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp253aaix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253aaix-pinctrl.dtsi
@@ -3289,6 +3289,98 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pk0: i2s2_sdi_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pk1: i2s2_sdo_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3461,6 +3553,112 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pj15: debug_traced7_pj15 {
+		pinmux = <STM32_PINMUX('J', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp253aajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253aajx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp253aakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253aakx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp253aalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253aalx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp253caix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253caix-pinctrl.dtsi
@@ -3289,6 +3289,98 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pk0: i2s2_sdi_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pk1: i2s2_sdo_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3461,6 +3553,112 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pj15: debug_traced7_pj15 {
+		pinmux = <STM32_PINMUX('J', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp253cajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253cajx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp253cakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253cakx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp253calx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253calx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp253daix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253daix-pinctrl.dtsi
@@ -3289,6 +3289,98 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pk0: i2s2_sdi_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pk1: i2s2_sdo_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3461,6 +3553,112 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pj15: debug_traced7_pj15 {
+		pinmux = <STM32_PINMUX('J', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp253dajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253dajx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp253dakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253dakx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp253dalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253dalx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp253faix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253faix-pinctrl.dtsi
@@ -3289,6 +3289,98 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pk0: i2s2_sdi_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pk1: i2s2_sdo_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3461,6 +3553,112 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pj15: debug_traced7_pj15 {
+		pinmux = <STM32_PINMUX('J', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp253fajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253fajx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp253fakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253fakx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp253falx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253falx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp255aaix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255aaix-pinctrl.dtsi
@@ -3289,6 +3289,98 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pk0: i2s2_sdi_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pk1: i2s2_sdo_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3461,6 +3553,112 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pj15: debug_traced7_pj15 {
+		pinmux = <STM32_PINMUX('J', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp255aajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255aajx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp255aakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255aakx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp255aalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255aalx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp255caix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255caix-pinctrl.dtsi
@@ -3289,6 +3289,98 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pk0: i2s2_sdi_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pk1: i2s2_sdo_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3461,6 +3553,112 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pj15: debug_traced7_pj15 {
+		pinmux = <STM32_PINMUX('J', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp255cajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255cajx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp255cakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255cakx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp255calx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255calx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp255daix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255daix-pinctrl.dtsi
@@ -3289,6 +3289,98 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pk0: i2s2_sdi_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pk1: i2s2_sdo_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3461,6 +3553,112 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pj15: debug_traced7_pj15 {
+		pinmux = <STM32_PINMUX('J', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp255dajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255dajx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp255dakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255dakx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp255dalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255dalx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp255faix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255faix-pinctrl.dtsi
@@ -3289,6 +3289,98 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pk0: i2s2_sdi_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pk1: i2s2_sdo_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3461,6 +3553,112 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pj15: debug_traced7_pj15 {
+		pinmux = <STM32_PINMUX('J', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp255fajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255fajx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp255fakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255fakx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp255falx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255falx-pinctrl.dtsi
@@ -2750,6 +2750,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -2898,6 +2982,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp257aaix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257aaix-pinctrl.dtsi
@@ -3404,6 +3404,98 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pk0: i2s2_sdi_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pk1: i2s2_sdo_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3576,6 +3668,112 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pj15: debug_traced7_pj15 {
+		pinmux = <STM32_PINMUX('J', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp257aajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257aajx-pinctrl.dtsi
@@ -2860,6 +2860,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3008,6 +3092,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp257aakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257aakx-pinctrl.dtsi
@@ -2860,6 +2860,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3008,6 +3092,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp257aalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257aalx-pinctrl.dtsi
@@ -2860,6 +2860,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3008,6 +3092,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp257caix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257caix-pinctrl.dtsi
@@ -3404,6 +3404,98 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pk0: i2s2_sdi_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pk1: i2s2_sdo_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3576,6 +3668,112 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pj15: debug_traced7_pj15 {
+		pinmux = <STM32_PINMUX('J', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp257cajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257cajx-pinctrl.dtsi
@@ -2860,6 +2860,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3008,6 +3092,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp257cakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257cakx-pinctrl.dtsi
@@ -2860,6 +2860,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3008,6 +3092,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp257calx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257calx-pinctrl.dtsi
@@ -2860,6 +2860,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3008,6 +3092,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp257daix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257daix-pinctrl.dtsi
@@ -3404,6 +3404,98 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pk0: i2s2_sdi_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pk1: i2s2_sdo_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3576,6 +3668,112 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pj15: debug_traced7_pj15 {
+		pinmux = <STM32_PINMUX('J', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp257dajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257dajx-pinctrl.dtsi
@@ -2860,6 +2860,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3008,6 +3092,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp257dakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257dakx-pinctrl.dtsi
@@ -2860,6 +2860,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3008,6 +3092,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp257dalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257dalx-pinctrl.dtsi
@@ -2860,6 +2860,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3008,6 +3092,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp257faix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257faix-pinctrl.dtsi
@@ -3404,6 +3404,98 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pk0: i2s2_sdi_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pk1: i2s2_sdo_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3576,6 +3668,112 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pj15: debug_traced7_pj15 {
+		pinmux = <STM32_PINMUX('J', 15, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp257fajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257fajx-pinctrl.dtsi
@@ -2860,6 +2860,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3008,6 +3092,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp257fakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257fakx-pinctrl.dtsi
@@ -2860,6 +2860,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3008,6 +3092,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/mp2/stm32mp257falx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257falx-pinctrl.dtsi
@@ -2860,6 +2860,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pd1: i2s1_sdi_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pe2: i2s1_sdi_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pf12: i2s1_sdi_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_ph8: i2s1_sdi_ph8 {
+		pinmux = <STM32_PINMUX('H', 8, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pb6: i2s2_sdi_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd12: i2s2_sdi_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pa15: i2s3_sdi_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb10: i2s3_sdi_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc9: i2s3_sdi_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pe4: i2s3_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF3)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pd9: i2s1_sdo_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pe4: i2s1_sdo_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_ph7: i2s1_sdo_ph7 {
+		pinmux = <STM32_PINMUX('H', 7, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pi5: i2s1_sdo_pi5 {
+		pinmux = <STM32_PINMUX('I', 5, AF3)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pb2: i2s2_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pi9: i2s2_sdo_pi9 {
+		pinmux = <STM32_PINMUX('I', 9, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb8: i2s3_sdo_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc1: i2s3_sdo_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc10: i2s3_sdo_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF2)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pe2: i2s3_sdo_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF3)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pd2: i2s1_ws_pd2 {
@@ -3008,6 +3092,108 @@
 	/omit-if-no-ref/ i3c4_sda_pz9: i3c4_sda_pz9 {
 		pinmux = <STM32_PINMUX('Z', 9, AF11)>;
 		slew-rate = "very-high-speed";
+	};
+
+	/* JTAG PORT */
+
+	/omit-if-no-ref/ debug_traceclk_pd0: debug_traceclk_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd4: debug_traced0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pd5: debug_traced1_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd6: debug_traced2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pd7: debug_traced3_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pd8: debug_traced4_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pd9: debug_traced5_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pd10: debug_traced6_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pd11: debug_traced7_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe0: debug_traced2_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe1: debug_traced3_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe3: debug_traceclk_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe4: debug_traced0_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe5: debug_traced1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf12: debug_traceclk_pf12 {
+		pinmux = <STM32_PINMUX('F', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf13: debug_traced0_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pf14: debug_traced1_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pf15: debug_traced2_pf15 {
+		pinmux = <STM32_PINMUX('F', 15, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pg5: debug_traced3_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced4_pg6: debug_traced4_pg6 {
+		pinmux = <STM32_PINMUX('G', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced5_pg7: debug_traced5_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced6_pg8: debug_traced6_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced7_pg9: debug_traced7_pg9 {
+		pinmux = <STM32_PINMUX('G', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced8_pg10: debug_traced8_pg10 {
+		pinmux = <STM32_PINMUX('G', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced9_pg11: debug_traced9_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/n6/stm32n645a0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645a0hxq-pinctrl.dtsi
@@ -1732,6 +1732,22 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa15: i2s1_ws_pa15 {
@@ -1805,8 +1821,16 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb3: debug_traceclk_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
@@ -1815,6 +1839,54 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd2: debug_traced0_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd10: debug_traceclk_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3014,7 +3086,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n645a0hxqg-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645a0hxqg-pinctrl.dtsi
@@ -1180,6 +1180,30 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc2: i2s3_sdo_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
@@ -1274,6 +1298,38 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2582,7 +2638,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n645b0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645b0hxq-pinctrl.dtsi
@@ -2356,6 +2356,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd6: i2s2_sdi_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd11: i2s2_sdi_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd2: i2s2_sdo_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd7: i2s2_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg8: i2s2_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa15: i2s1_ws_pa15 {
@@ -2484,8 +2560,16 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb3: debug_traceclk_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
@@ -2494,6 +2578,62 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd2: debug_traced0_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd10: debug_traceclk_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf9: debug_traced0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg3: debug_traced1_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4369,7 +4509,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n645i0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645i0hxq-pinctrl.dtsi
@@ -2102,6 +2102,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd6: i2s2_sdi_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd11: i2s2_sdi_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd2: i2s2_sdo_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd7: i2s2_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg8: i2s2_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa15: i2s1_ws_pa15 {
@@ -2230,8 +2310,16 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb3: debug_traceclk_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
@@ -2240,6 +2328,54 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd2: debug_traced0_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd10: debug_traceclk_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4010,7 +4146,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n645l0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645l0hxq-pinctrl.dtsi
@@ -2605,6 +2605,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb8: i2s1_sdi_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd6: i2s2_sdi_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd11: i2s2_sdi_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd2: i2s2_sdo_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd7: i2s2_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg8: i2s2_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa15: i2s1_ws_pa15 {
@@ -2737,8 +2821,16 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb3: debug_traceclk_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
@@ -2747,6 +2839,66 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb13: debug_traced0_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd2: debug_traced0_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd10: debug_traceclk_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf9: debug_traced0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg3: debug_traced1_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4879,7 +5031,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n645x0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645x0hxq-pinctrl.dtsi
@@ -2804,6 +2804,106 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb8: i2s1_sdi_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc4: i2s2_sdi_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd6: i2s2_sdi_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd11: i2s2_sdi_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pe4: i2s6_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc3: i2s1_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd2: i2s2_sdo_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd7: i2s2_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg8: i2s2_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc2: i2s3_sdo_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa15: i2s1_ws_pa15 {
@@ -2950,8 +3050,16 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb3: debug_traceclk_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
@@ -2960,6 +3068,78 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb13: debug_traced0_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd2: debug_traced0_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd10: debug_traceclk_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf9: debug_traced0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg3: debug_traced1_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pg7: debug_traceclk_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph3: debug_traceclk_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pq0: debug_traceclk_pq0 {
+		pinmux = <STM32_PINMUX('Q', 0, AF0)>;
 	};
 
 	/* LPTIM */
@@ -5389,7 +5569,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n645z0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645z0hxq-pinctrl.dtsi
@@ -982,12 +982,56 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1866,7 +1910,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n647a0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647a0hxq-pinctrl.dtsi
@@ -1732,6 +1732,22 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa15: i2s1_ws_pa15 {
@@ -1805,8 +1821,16 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb3: debug_traceclk_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
@@ -1815,6 +1839,54 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd2: debug_traced0_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd10: debug_traceclk_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3014,7 +3086,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n647a0hxqg-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647a0hxqg-pinctrl.dtsi
@@ -1180,6 +1180,30 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc2: i2s3_sdo_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
@@ -1274,6 +1298,38 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2582,7 +2638,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n647b0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647b0hxq-pinctrl.dtsi
@@ -2356,6 +2356,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd6: i2s2_sdi_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd11: i2s2_sdi_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd2: i2s2_sdo_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd7: i2s2_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg8: i2s2_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa15: i2s1_ws_pa15 {
@@ -2484,8 +2560,16 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb3: debug_traceclk_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
@@ -2494,6 +2578,62 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd2: debug_traced0_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd10: debug_traceclk_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf9: debug_traced0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg3: debug_traced1_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4369,7 +4509,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n647i0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647i0hxq-pinctrl.dtsi
@@ -2102,6 +2102,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd6: i2s2_sdi_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd11: i2s2_sdi_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd2: i2s2_sdo_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd7: i2s2_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg8: i2s2_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa15: i2s1_ws_pa15 {
@@ -2230,8 +2310,16 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb3: debug_traceclk_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
@@ -2240,6 +2328,54 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd2: debug_traced0_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd10: debug_traceclk_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4010,7 +4146,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n647l0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647l0hxq-pinctrl.dtsi
@@ -2605,6 +2605,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb8: i2s1_sdi_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd6: i2s2_sdi_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd11: i2s2_sdi_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd2: i2s2_sdo_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd7: i2s2_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg8: i2s2_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa15: i2s1_ws_pa15 {
@@ -2737,8 +2821,16 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb3: debug_traceclk_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
@@ -2747,6 +2839,66 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb13: debug_traced0_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd2: debug_traced0_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd10: debug_traceclk_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf9: debug_traced0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg3: debug_traced1_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4879,7 +5031,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n647x0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647x0hxq-pinctrl.dtsi
@@ -2804,6 +2804,106 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb8: i2s1_sdi_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc4: i2s2_sdi_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd6: i2s2_sdi_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd11: i2s2_sdi_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pe4: i2s6_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc3: i2s1_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd2: i2s2_sdo_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd7: i2s2_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg8: i2s2_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc2: i2s3_sdo_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa15: i2s1_ws_pa15 {
@@ -2950,8 +3050,16 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb3: debug_traceclk_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
@@ -2960,6 +3068,78 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb13: debug_traced0_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd2: debug_traced0_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd10: debug_traceclk_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf9: debug_traced0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg3: debug_traced1_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pg7: debug_traceclk_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph3: debug_traceclk_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pq0: debug_traceclk_pq0 {
+		pinmux = <STM32_PINMUX('Q', 0, AF0)>;
 	};
 
 	/* LPTIM */
@@ -5389,7 +5569,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n647z0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647z0hxq-pinctrl.dtsi
@@ -982,12 +982,56 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1866,7 +1910,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n655a0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655a0hxq-pinctrl.dtsi
@@ -1732,6 +1732,22 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa15: i2s1_ws_pa15 {
@@ -1805,8 +1821,16 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb3: debug_traceclk_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
@@ -1815,6 +1839,54 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd2: debug_traced0_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd10: debug_traceclk_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3014,7 +3086,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n655a0hxqg-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655a0hxqg-pinctrl.dtsi
@@ -1180,6 +1180,30 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc2: i2s3_sdo_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
@@ -1274,6 +1298,38 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2582,7 +2638,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n655b0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655b0hxq-pinctrl.dtsi
@@ -2356,6 +2356,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd6: i2s2_sdi_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd11: i2s2_sdi_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd2: i2s2_sdo_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd7: i2s2_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg8: i2s2_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa15: i2s1_ws_pa15 {
@@ -2484,8 +2560,16 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb3: debug_traceclk_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
@@ -2494,6 +2578,62 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd2: debug_traced0_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd10: debug_traceclk_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf9: debug_traced0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg3: debug_traced1_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4369,7 +4509,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n655i0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655i0hxq-pinctrl.dtsi
@@ -2102,6 +2102,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd6: i2s2_sdi_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd11: i2s2_sdi_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd2: i2s2_sdo_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd7: i2s2_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg8: i2s2_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa15: i2s1_ws_pa15 {
@@ -2230,8 +2310,16 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb3: debug_traceclk_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
@@ -2240,6 +2328,54 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd2: debug_traced0_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd10: debug_traceclk_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4010,7 +4146,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n655l0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655l0hxq-pinctrl.dtsi
@@ -2605,6 +2605,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb8: i2s1_sdi_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd6: i2s2_sdi_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd11: i2s2_sdi_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd2: i2s2_sdo_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd7: i2s2_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg8: i2s2_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa15: i2s1_ws_pa15 {
@@ -2737,8 +2821,16 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb3: debug_traceclk_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
@@ -2747,6 +2839,66 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb13: debug_traced0_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd2: debug_traced0_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd10: debug_traceclk_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf9: debug_traced0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg3: debug_traced1_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4879,7 +5031,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n655x0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655x0hxq-pinctrl.dtsi
@@ -2804,6 +2804,106 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb8: i2s1_sdi_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc4: i2s2_sdi_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd6: i2s2_sdi_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd11: i2s2_sdi_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pe4: i2s6_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc3: i2s1_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd2: i2s2_sdo_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd7: i2s2_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg8: i2s2_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc2: i2s3_sdo_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa15: i2s1_ws_pa15 {
@@ -2950,8 +3050,16 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb3: debug_traceclk_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
@@ -2960,6 +3068,78 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb13: debug_traced0_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd2: debug_traced0_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd10: debug_traceclk_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf9: debug_traced0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg3: debug_traced1_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pg7: debug_traceclk_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph3: debug_traceclk_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pq0: debug_traceclk_pq0 {
+		pinmux = <STM32_PINMUX('Q', 0, AF0)>;
 	};
 
 	/* LPTIM */
@@ -5389,7 +5569,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n655z0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655z0hxq-pinctrl.dtsi
@@ -982,12 +982,56 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1866,7 +1910,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n657a0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657a0hxq-pinctrl.dtsi
@@ -1732,6 +1732,22 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa15: i2s1_ws_pa15 {
@@ -1805,8 +1821,16 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb3: debug_traceclk_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
@@ -1815,6 +1839,54 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd2: debug_traced0_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd10: debug_traceclk_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3014,7 +3086,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n657a0hxqg-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657a0hxqg-pinctrl.dtsi
@@ -1180,6 +1180,30 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc2: i2s3_sdo_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s3_ws_pa15: i2s3_ws_pa15 {
@@ -1274,6 +1298,38 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2582,7 +2638,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n657b0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657b0hxq-pinctrl.dtsi
@@ -2356,6 +2356,82 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd6: i2s2_sdi_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd11: i2s2_sdi_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd2: i2s2_sdo_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd7: i2s2_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg8: i2s2_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa15: i2s1_ws_pa15 {
@@ -2484,8 +2560,16 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb3: debug_traceclk_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
@@ -2494,6 +2578,62 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd2: debug_traced0_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd10: debug_traceclk_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf9: debug_traced0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg3: debug_traced1_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4369,7 +4509,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n657i0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657i0hxq-pinctrl.dtsi
@@ -2102,6 +2102,86 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd6: i2s2_sdi_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd11: i2s2_sdi_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd2: i2s2_sdo_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd7: i2s2_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg8: i2s2_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa15: i2s1_ws_pa15 {
@@ -2230,8 +2310,16 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb3: debug_traceclk_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
@@ -2240,6 +2328,54 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd2: debug_traced0_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd10: debug_traceclk_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4010,7 +4146,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n657l0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657l0hxq-pinctrl.dtsi
@@ -2605,6 +2605,90 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb8: i2s1_sdi_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd6: i2s2_sdi_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd11: i2s2_sdi_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd2: i2s2_sdo_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd7: i2s2_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg8: i2s2_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa15: i2s1_ws_pa15 {
@@ -2737,8 +2821,16 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb3: debug_traceclk_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
@@ -2747,6 +2839,66 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb13: debug_traced0_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd2: debug_traced0_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd10: debug_traceclk_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf9: debug_traced0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg3: debug_traced1_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -4879,7 +5031,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n657x0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657x0hxq-pinctrl.dtsi
@@ -2804,6 +2804,106 @@
 		slew-rate = "very-high-speed";
 	};
 
+	/* I2S_SDI */
+
+	/omit-if-no-ref/ i2s1_sdi_pa6: i2s1_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb4: i2s1_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdi_pb8: i2s1_sdi_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pc4: i2s2_sdi_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd6: i2s2_sdi_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdi_pd11: i2s2_sdi_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pb4: i2s3_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdi_pc11: i2s3_sdi_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pa6: i2s6_sdi_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pb4: i2s6_sdi_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdi_pe4: i2s6_sdi_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF5)>;
+	};
+
+	/* I2S_SDO */
+
+	/omit-if-no-ref/ i2s1_sdo_pa7: i2s1_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pb5: i2s1_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s1_sdo_pc3: i2s1_sdo_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd2: i2s2_sdo_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pd7: i2s2_sdo_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s2_sdo_pg8: i2s2_sdo_pg8 {
+		pinmux = <STM32_PINMUX('G', 8, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb2: i2s3_sdo_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pb5: i2s3_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF7)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc2: i2s3_sdo_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ i2s3_sdo_pc12: i2s3_sdo_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF6)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pa7: i2s6_sdo_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pb5: i2s6_sdo_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF8)>;
+	};
+
+	/omit-if-no-ref/ i2s6_sdo_pg14: i2s6_sdo_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+	};
+
 	/* I2S_WS */
 
 	/omit-if-no-ref/ i2s1_ws_pa15: i2s1_ws_pa15 {
@@ -2950,8 +3050,16 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb3: debug_traceclk_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
@@ -2960,6 +3068,78 @@
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pb13: debug_traced0_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pd2: debug_traced0_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pd10: debug_traceclk_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pf9: debug_traced0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg3: debug_traced1_pg3 {
+		pinmux = <STM32_PINMUX('G', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pg7: debug_traceclk_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_ph3: debug_traceclk_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pq0: debug_traceclk_pq0 {
+		pinmux = <STM32_PINMUX('Q', 0, AF0)>;
 	};
 
 	/* LPTIM */
@@ -5389,7 +5569,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/n6/stm32n657z0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657z0hxq-pinctrl.dtsi
@@ -982,12 +982,56 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb0: debug_traced1_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
 	/omit-if-no-ref/ debug_jtdo_swo_pb5: debug_jtdo_swo_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb6: debug_traced2_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb7: debug_traced3_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe10: debug_traceclk_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pf8: debug_traceclk_pf8 {
+		pinmux = <STM32_PINMUX('F', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_ph2: debug_traced2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1866,7 +1910,7 @@
 		bias-pull-up;
 	};
 
-	/* XSPIM */
+	/* XSPI */
 
 	/omit-if-no-ref/ xspim_p2_dqs0_pn0: xspim_p2_dqs0_pn0 {
 		pinmux = <STM32_PINMUX('N', 0, AF9)>;

--- a/dts/st/u3/stm32u375cetx-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375cetx-pinctrl.dtsi
@@ -520,6 +520,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1417,6 +1421,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1427,6 +1435,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u375cetxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375cetxq-pinctrl.dtsi
@@ -430,6 +430,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1227,6 +1231,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1237,6 +1245,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u375ceux-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375ceux-pinctrl.dtsi
@@ -520,6 +520,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1417,6 +1421,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1427,6 +1435,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u375ceuxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375ceuxq-pinctrl.dtsi
@@ -430,6 +430,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1227,6 +1231,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1237,6 +1245,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u375ceyxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375ceyxq-pinctrl.dtsi
@@ -477,6 +477,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1305,6 +1309,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1315,6 +1323,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u375cgtx-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375cgtx-pinctrl.dtsi
@@ -520,6 +520,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1417,6 +1421,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1427,6 +1435,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u375cgtxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375cgtxq-pinctrl.dtsi
@@ -430,6 +430,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1227,6 +1231,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1237,6 +1245,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u375cgux-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375cgux-pinctrl.dtsi
@@ -520,6 +520,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1417,6 +1421,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1427,6 +1435,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u375cguxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375cguxq-pinctrl.dtsi
@@ -430,6 +430,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1227,6 +1231,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1237,6 +1245,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u375cgyxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375cgyxq-pinctrl.dtsi
@@ -477,6 +477,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1305,6 +1309,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1315,6 +1323,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u375keux-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375keux-pinctrl.dtsi
@@ -330,6 +330,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1011,6 +1015,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1021,6 +1029,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u375kgux-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375kgux-pinctrl.dtsi
@@ -330,6 +330,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1011,6 +1015,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1021,6 +1029,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u375reix-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375reix-pinctrl.dtsi
@@ -643,6 +643,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -661,6 +665,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1908,6 +1932,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1918,6 +1946,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u375reixq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375reixq-pinctrl.dtsi
@@ -573,6 +573,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -591,6 +595,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1749,6 +1773,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1759,6 +1787,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u375retx-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375retx-pinctrl.dtsi
@@ -643,6 +643,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -661,6 +665,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1908,6 +1932,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1918,6 +1946,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u375retxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375retxq-pinctrl.dtsi
@@ -573,6 +573,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -591,6 +595,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1749,6 +1773,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1759,6 +1787,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u375reyxg-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375reyxg-pinctrl.dtsi
@@ -549,6 +549,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1540,6 +1544,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1550,6 +1558,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u375reyxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375reyxq-pinctrl.dtsi
@@ -663,6 +663,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -681,6 +685,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1962,6 +1986,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1972,6 +2000,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u375rgix-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375rgix-pinctrl.dtsi
@@ -643,6 +643,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -661,6 +665,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1908,6 +1932,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1918,6 +1946,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u375rgixq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375rgixq-pinctrl.dtsi
@@ -573,6 +573,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -591,6 +595,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1749,6 +1773,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1759,6 +1787,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u375rgtx-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375rgtx-pinctrl.dtsi
@@ -643,6 +643,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -661,6 +665,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1908,6 +1932,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1918,6 +1946,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u375rgtxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375rgtxq-pinctrl.dtsi
@@ -573,6 +573,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -591,6 +595,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1749,6 +1773,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1759,6 +1787,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u375rgyxg-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375rgyxg-pinctrl.dtsi
@@ -549,6 +549,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1540,6 +1544,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1550,6 +1558,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u375rgyxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375rgyxq-pinctrl.dtsi
@@ -663,6 +663,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -681,6 +685,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1962,6 +1986,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1972,6 +2000,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u375veix-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375veix-pinctrl.dtsi
@@ -814,6 +814,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -832,6 +836,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2455,6 +2499,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2465,6 +2513,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u375veixq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375veixq-pinctrl.dtsi
@@ -773,6 +773,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -791,6 +795,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2373,6 +2417,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2383,6 +2431,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u375vetx-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375vetx-pinctrl.dtsi
@@ -814,6 +814,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -832,6 +836,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2455,6 +2499,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2465,6 +2513,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u375vetxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375vetxq-pinctrl.dtsi
@@ -773,6 +773,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -791,6 +795,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2373,6 +2417,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2383,6 +2431,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u375vgix-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375vgix-pinctrl.dtsi
@@ -814,6 +814,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -832,6 +836,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2455,6 +2499,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2465,6 +2513,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u375vgixq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375vgixq-pinctrl.dtsi
@@ -773,6 +773,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -791,6 +795,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2373,6 +2417,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2383,6 +2431,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u375vgtx-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375vgtx-pinctrl.dtsi
@@ -814,6 +814,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -832,6 +836,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2455,6 +2499,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2465,6 +2513,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u375vgtxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u375vgtxq-pinctrl.dtsi
@@ -773,6 +773,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -791,6 +795,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2373,6 +2417,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2383,6 +2431,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u385cgtx-pinctrl.dtsi
+++ b/dts/st/u3/stm32u385cgtx-pinctrl.dtsi
@@ -520,6 +520,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1417,6 +1421,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1427,6 +1435,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u385cgtxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u385cgtxq-pinctrl.dtsi
@@ -430,6 +430,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1227,6 +1231,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1237,6 +1245,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u385cgux-pinctrl.dtsi
+++ b/dts/st/u3/stm32u385cgux-pinctrl.dtsi
@@ -520,6 +520,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1417,6 +1421,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1427,6 +1435,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u385cguxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u385cguxq-pinctrl.dtsi
@@ -430,6 +430,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1227,6 +1231,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1237,6 +1245,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u385cgyxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u385cgyxq-pinctrl.dtsi
@@ -477,6 +477,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1305,6 +1309,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1315,6 +1323,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u385kgux-pinctrl.dtsi
+++ b/dts/st/u3/stm32u385kgux-pinctrl.dtsi
@@ -330,6 +330,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1011,6 +1015,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1021,6 +1029,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u385rgix-pinctrl.dtsi
+++ b/dts/st/u3/stm32u385rgix-pinctrl.dtsi
@@ -643,6 +643,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -661,6 +665,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1908,6 +1932,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1918,6 +1946,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u385rgixq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u385rgixq-pinctrl.dtsi
@@ -573,6 +573,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -591,6 +595,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1749,6 +1773,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1759,6 +1787,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u385rgtx-pinctrl.dtsi
+++ b/dts/st/u3/stm32u385rgtx-pinctrl.dtsi
@@ -643,6 +643,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -661,6 +665,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1908,6 +1932,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1918,6 +1946,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u385rgtxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u385rgtxq-pinctrl.dtsi
@@ -573,6 +573,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -591,6 +595,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1757,6 +1781,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1767,6 +1795,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u385rgyxg-pinctrl.dtsi
+++ b/dts/st/u3/stm32u385rgyxg-pinctrl.dtsi
@@ -549,6 +549,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1540,6 +1544,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1550,6 +1558,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u385rgyxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u385rgyxq-pinctrl.dtsi
@@ -663,6 +663,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -681,6 +685,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1962,6 +1986,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1972,6 +2000,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u385vgix-pinctrl.dtsi
+++ b/dts/st/u3/stm32u385vgix-pinctrl.dtsi
@@ -814,6 +814,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -832,6 +836,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2455,6 +2499,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2465,6 +2513,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u385vgixq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u385vgixq-pinctrl.dtsi
@@ -773,6 +773,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -791,6 +795,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2373,6 +2417,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2383,6 +2431,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u385vgtx-pinctrl.dtsi
+++ b/dts/st/u3/stm32u385vgtx-pinctrl.dtsi
@@ -814,6 +814,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -832,6 +836,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2455,6 +2499,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2465,6 +2513,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u385vgtxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u385vgtxq-pinctrl.dtsi
@@ -773,6 +773,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -791,6 +795,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2373,6 +2417,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2383,6 +2431,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u3/stm32u3b5cgtx-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5cgtx-pinctrl.dtsi
@@ -579,6 +579,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1586,6 +1590,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5cgtxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5cgtxq-pinctrl.dtsi
@@ -474,6 +474,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1377,6 +1381,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5cgux-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5cgux-pinctrl.dtsi
@@ -579,6 +579,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1586,6 +1590,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5cguxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5cguxq-pinctrl.dtsi
@@ -474,6 +474,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1377,6 +1381,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5citx-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5citx-pinctrl.dtsi
@@ -579,6 +579,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1586,6 +1590,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5citxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5citxq-pinctrl.dtsi
@@ -474,6 +474,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1377,6 +1381,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5ciux-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5ciux-pinctrl.dtsi
@@ -579,6 +579,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1586,6 +1590,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5ciuxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5ciuxq-pinctrl.dtsi
@@ -474,6 +474,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1377,6 +1381,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5jgyxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5jgyxq-pinctrl.dtsi
@@ -710,6 +710,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -728,6 +732,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2212,6 +2236,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5jiyxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5jiyxq-pinctrl.dtsi
@@ -710,6 +710,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -728,6 +732,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2212,6 +2236,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5qgix-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5qgix-pinctrl.dtsi
@@ -1106,6 +1106,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1124,6 +1128,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3320,6 +3364,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5qgixq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5qgixq-pinctrl.dtsi
@@ -1063,6 +1063,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1081,6 +1085,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3218,6 +3262,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5qiix-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5qiix-pinctrl.dtsi
@@ -1106,6 +1106,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1124,6 +1128,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3320,6 +3364,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5qiixq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5qiixq-pinctrl.dtsi
@@ -1063,6 +1063,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1081,6 +1085,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3218,6 +3262,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5rgtx-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5rgtx-pinctrl.dtsi
@@ -702,6 +702,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -720,6 +724,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2097,6 +2121,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5rgtxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5rgtxq-pinctrl.dtsi
@@ -623,6 +623,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -641,6 +645,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1929,6 +1953,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5ritx-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5ritx-pinctrl.dtsi
@@ -702,6 +702,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -720,6 +724,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2097,6 +2121,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5ritxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5ritxq-pinctrl.dtsi
@@ -623,6 +623,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -641,6 +645,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1929,6 +1953,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5vgtx-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5vgtx-pinctrl.dtsi
@@ -890,6 +890,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -908,6 +912,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2737,6 +2781,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5vgtxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5vgtxq-pinctrl.dtsi
@@ -851,6 +851,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -869,6 +873,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2657,6 +2701,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5vgyxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5vgyxq-pinctrl.dtsi
@@ -852,6 +852,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -870,6 +874,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2782,6 +2826,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5vitx-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5vitx-pinctrl.dtsi
@@ -890,6 +890,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -908,6 +912,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2737,6 +2781,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5vitxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5vitxq-pinctrl.dtsi
@@ -851,6 +851,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -869,6 +873,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2657,6 +2701,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5viyxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5viyxq-pinctrl.dtsi
@@ -852,6 +852,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -870,6 +874,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2782,6 +2826,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5wgyxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5wgyxq-pinctrl.dtsi
@@ -1044,6 +1044,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1062,6 +1066,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3262,6 +3306,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5wiyxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5wiyxq-pinctrl.dtsi
@@ -1044,6 +1044,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1062,6 +1066,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3262,6 +3306,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5zgtx-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5zgtx-pinctrl.dtsi
@@ -1114,6 +1114,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1132,6 +1136,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3367,6 +3411,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5zgtxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5zgtxq-pinctrl.dtsi
@@ -1075,6 +1075,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1093,6 +1097,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3255,6 +3299,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5zitx-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5zitx-pinctrl.dtsi
@@ -1114,6 +1114,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1132,6 +1136,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3367,6 +3411,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3b5zitxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3b5zitxq-pinctrl.dtsi
@@ -1075,6 +1075,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1093,6 +1097,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3255,6 +3299,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3c5citx-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3c5citx-pinctrl.dtsi
@@ -579,6 +579,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1586,6 +1590,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3c5citxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3c5citxq-pinctrl.dtsi
@@ -474,6 +474,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1377,6 +1381,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3c5ciux-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3c5ciux-pinctrl.dtsi
@@ -579,6 +579,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1586,6 +1590,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3c5ciuxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3c5ciuxq-pinctrl.dtsi
@@ -474,6 +474,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1377,6 +1381,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3c5jiyxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3c5jiyxq-pinctrl.dtsi
@@ -710,6 +710,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -728,6 +732,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2212,6 +2236,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3c5qiix-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3c5qiix-pinctrl.dtsi
@@ -1106,6 +1106,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1124,6 +1128,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3320,6 +3364,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3c5qiixq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3c5qiixq-pinctrl.dtsi
@@ -1063,6 +1063,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1081,6 +1085,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3218,6 +3262,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3c5ritx-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3c5ritx-pinctrl.dtsi
@@ -702,6 +702,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -720,6 +724,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2097,6 +2121,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3c5ritxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3c5ritxq-pinctrl.dtsi
@@ -623,6 +623,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -641,6 +645,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1929,6 +1953,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3c5vitx-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3c5vitx-pinctrl.dtsi
@@ -890,6 +890,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -908,6 +912,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2737,6 +2781,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3c5vitxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3c5vitxq-pinctrl.dtsi
@@ -851,6 +851,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -869,6 +873,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2657,6 +2701,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3c5viyxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3c5viyxq-pinctrl.dtsi
@@ -852,6 +852,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -870,6 +874,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2782,6 +2826,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3c5wiyxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3c5wiyxq-pinctrl.dtsi
@@ -1044,6 +1044,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1062,6 +1066,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3262,6 +3306,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3c5zitx-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3c5zitx-pinctrl.dtsi
@@ -1114,6 +1114,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1132,6 +1136,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3367,6 +3411,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u3/stm32u3c5zitxq-pinctrl.dtsi
+++ b/dts/st/u3/stm32u3c5zitxq-pinctrl.dtsi
@@ -1075,6 +1075,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1093,6 +1097,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -3255,6 +3299,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u535cbtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cbtx-pinctrl.dtsi
@@ -410,6 +410,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1302,6 +1306,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1312,6 +1320,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u535cbtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cbtxq-pinctrl.dtsi
@@ -350,6 +350,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1138,6 +1142,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1148,6 +1156,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u535cbux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cbux-pinctrl.dtsi
@@ -410,6 +410,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1302,6 +1306,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1312,6 +1320,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u535cbuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cbuxq-pinctrl.dtsi
@@ -350,6 +350,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1138,6 +1142,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1148,6 +1156,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u535cctx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cctx-pinctrl.dtsi
@@ -410,6 +410,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1302,6 +1306,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1312,6 +1320,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u535cctxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cctxq-pinctrl.dtsi
@@ -350,6 +350,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1138,6 +1142,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1148,6 +1156,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u535ccux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535ccux-pinctrl.dtsi
@@ -410,6 +410,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1302,6 +1306,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1312,6 +1320,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u535ccuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535ccuxq-pinctrl.dtsi
@@ -350,6 +350,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1138,6 +1142,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1148,6 +1156,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u535cetx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cetx-pinctrl.dtsi
@@ -410,6 +410,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1302,6 +1306,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1312,6 +1320,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u535cetxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cetxq-pinctrl.dtsi
@@ -350,6 +350,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1138,6 +1142,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1148,6 +1156,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u535ceux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535ceux-pinctrl.dtsi
@@ -410,6 +410,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1302,6 +1306,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1312,6 +1320,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u535ceuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535ceuxq-pinctrl.dtsi
@@ -350,6 +350,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1138,6 +1142,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1148,6 +1156,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u535jeyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535jeyxq-pinctrl.dtsi
@@ -495,6 +495,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -513,6 +517,10 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1542,6 +1550,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1552,6 +1564,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u535ncyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535ncyxq-pinctrl.dtsi
@@ -402,6 +402,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -420,6 +424,18 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1322,6 +1338,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1332,6 +1352,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u535neyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535neyxq-pinctrl.dtsi
@@ -402,6 +402,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -420,6 +424,18 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1322,6 +1338,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1332,6 +1352,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u535rbix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rbix-pinctrl.dtsi
@@ -534,6 +534,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -552,6 +556,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1794,6 +1818,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1804,6 +1832,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u535rbixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rbixq-pinctrl.dtsi
@@ -479,6 +479,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -497,6 +501,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1650,6 +1674,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1660,6 +1688,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u535rbtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rbtx-pinctrl.dtsi
@@ -534,6 +534,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -552,6 +556,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1794,6 +1818,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1804,6 +1832,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u535rbtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rbtxq-pinctrl.dtsi
@@ -479,6 +479,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -497,6 +501,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1650,6 +1674,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1660,6 +1688,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u535rcix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rcix-pinctrl.dtsi
@@ -534,6 +534,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -552,6 +556,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1794,6 +1818,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1804,6 +1832,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u535rcixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rcixq-pinctrl.dtsi
@@ -479,6 +479,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -497,6 +501,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1650,6 +1674,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1660,6 +1688,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u535rctx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rctx-pinctrl.dtsi
@@ -534,6 +534,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -552,6 +556,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1794,6 +1818,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1804,6 +1832,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u535rctxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rctxq-pinctrl.dtsi
@@ -479,6 +479,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -497,6 +501,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1650,6 +1674,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1660,6 +1688,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u535reix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535reix-pinctrl.dtsi
@@ -534,6 +534,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -552,6 +556,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1794,6 +1818,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1804,6 +1832,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u535reixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535reixq-pinctrl.dtsi
@@ -479,6 +479,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -497,6 +501,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1650,6 +1674,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1660,6 +1688,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u535retx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535retx-pinctrl.dtsi
@@ -534,6 +534,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -552,6 +556,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1794,6 +1818,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1804,6 +1832,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u535retxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535retxq-pinctrl.dtsi
@@ -479,6 +479,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -497,6 +501,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1650,6 +1674,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1660,6 +1688,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u535vcix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vcix-pinctrl.dtsi
@@ -837,6 +837,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -855,6 +859,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2482,6 +2526,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2492,6 +2540,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u535vcixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vcixq-pinctrl.dtsi
@@ -803,6 +803,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -821,6 +825,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2407,6 +2451,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2417,6 +2465,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u535vctx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vctx-pinctrl.dtsi
@@ -837,6 +837,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -855,6 +859,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2482,6 +2526,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2492,6 +2540,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u535vctxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vctxq-pinctrl.dtsi
@@ -803,6 +803,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -821,6 +825,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2407,6 +2451,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2417,6 +2465,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u535veix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535veix-pinctrl.dtsi
@@ -837,6 +837,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -855,6 +859,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2482,6 +2526,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2492,6 +2540,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u535veixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535veixq-pinctrl.dtsi
@@ -803,6 +803,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -821,6 +825,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2407,6 +2451,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2417,6 +2465,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u535vetx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vetx-pinctrl.dtsi
@@ -837,6 +837,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -855,6 +859,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2482,6 +2526,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2492,6 +2540,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u535vetxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vetxq-pinctrl.dtsi
@@ -803,6 +803,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -821,6 +825,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2407,6 +2451,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2417,6 +2465,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u545cetx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545cetx-pinctrl.dtsi
@@ -410,6 +410,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1302,6 +1306,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1312,6 +1320,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u545cetxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545cetxq-pinctrl.dtsi
@@ -350,6 +350,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1138,6 +1142,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1148,6 +1156,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u545ceux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545ceux-pinctrl.dtsi
@@ -410,6 +410,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1302,6 +1306,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1312,6 +1320,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u545ceuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545ceuxq-pinctrl.dtsi
@@ -350,6 +350,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1138,6 +1142,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1148,6 +1156,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u545jeyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545jeyxq-pinctrl.dtsi
@@ -495,6 +495,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -513,6 +517,10 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1542,6 +1550,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1552,6 +1564,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u545neyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545neyxq-pinctrl.dtsi
@@ -402,6 +402,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -420,6 +424,18 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1322,6 +1338,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1332,6 +1352,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 };

--- a/dts/st/u5/stm32u545reix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545reix-pinctrl.dtsi
@@ -534,6 +534,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -552,6 +556,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1794,6 +1818,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1804,6 +1832,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u545reixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545reixq-pinctrl.dtsi
@@ -479,6 +479,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -497,6 +501,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1650,6 +1674,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1660,6 +1688,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u545retx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545retx-pinctrl.dtsi
@@ -534,6 +534,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -552,6 +556,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1794,6 +1818,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1804,6 +1832,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u545retxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545retxq-pinctrl.dtsi
@@ -479,6 +479,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -497,6 +501,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */
@@ -1650,6 +1674,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -1660,6 +1688,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u545veix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545veix-pinctrl.dtsi
@@ -837,6 +837,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -855,6 +859,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2482,6 +2526,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2492,6 +2540,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u545veixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545veixq-pinctrl.dtsi
@@ -803,6 +803,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -821,6 +825,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2407,6 +2451,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2417,6 +2465,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u545vetx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545vetx-pinctrl.dtsi
@@ -837,6 +837,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -855,6 +859,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2482,6 +2526,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2492,6 +2540,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u545vetxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545vetxq-pinctrl.dtsi
@@ -803,6 +803,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -821,6 +825,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */
@@ -2407,6 +2451,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
 	};
@@ -2417,6 +2465,10 @@
 
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF10)>;
+	};
+
+	/omit-if-no-ref/ usb_sof_pa14: usb_sof_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF10)>;
 	};
 
 	/omit-if-no-ref/ usb_noe_pc9: usb_noe_pc9 {

--- a/dts/st/u5/stm32u575agix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575agix-pinctrl.dtsi
@@ -1677,6 +1677,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1695,6 +1699,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u575agixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575agixq-pinctrl.dtsi
@@ -1641,6 +1641,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1659,6 +1663,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u575aiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575aiix-pinctrl.dtsi
@@ -1677,6 +1677,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1695,6 +1699,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u575aiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575aiixq-pinctrl.dtsi
@@ -1641,6 +1641,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1659,6 +1663,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u575cgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cgtx-pinctrl.dtsi
@@ -418,6 +418,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};

--- a/dts/st/u5/stm32u575cgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cgtxq-pinctrl.dtsi
@@ -358,6 +358,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};

--- a/dts/st/u5/stm32u575cgux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cgux-pinctrl.dtsi
@@ -418,6 +418,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};

--- a/dts/st/u5/stm32u575cguxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cguxq-pinctrl.dtsi
@@ -358,6 +358,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};

--- a/dts/st/u5/stm32u575citx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575citx-pinctrl.dtsi
@@ -418,6 +418,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};

--- a/dts/st/u5/stm32u575citxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575citxq-pinctrl.dtsi
@@ -358,6 +358,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};

--- a/dts/st/u5/stm32u575ciux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ciux-pinctrl.dtsi
@@ -418,6 +418,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};

--- a/dts/st/u5/stm32u575ciuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ciuxq-pinctrl.dtsi
@@ -358,6 +358,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};

--- a/dts/st/u5/stm32u575ogyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ogyxq-pinctrl.dtsi
@@ -863,6 +863,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -881,6 +885,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u575oiyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575oiyxq-pinctrl.dtsi
@@ -863,6 +863,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -881,6 +885,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u575qgix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qgix-pinctrl.dtsi
@@ -1423,6 +1423,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1441,6 +1445,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u575qgixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qgixq-pinctrl.dtsi
@@ -1373,6 +1373,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1391,6 +1395,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u575qiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qiix-pinctrl.dtsi
@@ -1423,6 +1423,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1441,6 +1445,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u575qiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qiixq-pinctrl.dtsi
@@ -1373,6 +1373,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1391,6 +1395,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u575rgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575rgtx-pinctrl.dtsi
@@ -639,6 +639,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -657,6 +661,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u575rgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575rgtxq-pinctrl.dtsi
@@ -487,6 +487,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -505,6 +509,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u575ritx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ritx-pinctrl.dtsi
@@ -639,6 +639,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -657,6 +661,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u575ritxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ritxq-pinctrl.dtsi
@@ -487,6 +487,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -505,6 +509,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u575vgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vgtx-pinctrl.dtsi
@@ -1063,6 +1063,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1081,6 +1085,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u575vgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vgtxq-pinctrl.dtsi
@@ -1027,6 +1027,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1045,6 +1049,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u575vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vitx-pinctrl.dtsi
@@ -1063,6 +1063,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1081,6 +1085,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u575vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vitxq-pinctrl.dtsi
@@ -1027,6 +1027,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1045,6 +1049,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u575zgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zgtx-pinctrl.dtsi
@@ -1441,6 +1441,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1459,6 +1463,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u575zgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zgtxq-pinctrl.dtsi
@@ -1416,6 +1416,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1434,6 +1438,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u575zitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zitx-pinctrl.dtsi
@@ -1441,6 +1441,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1459,6 +1463,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u575zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zitxq-pinctrl.dtsi
@@ -1416,6 +1416,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1434,6 +1438,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u585aiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585aiix-pinctrl.dtsi
@@ -1677,6 +1677,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1695,6 +1699,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u585aiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585aiixq-pinctrl.dtsi
@@ -1641,6 +1641,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1659,6 +1663,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u585citx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585citx-pinctrl.dtsi
@@ -418,6 +418,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};

--- a/dts/st/u5/stm32u585citxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585citxq-pinctrl.dtsi
@@ -358,6 +358,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};

--- a/dts/st/u5/stm32u585ciux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ciux-pinctrl.dtsi
@@ -418,6 +418,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};

--- a/dts/st/u5/stm32u585ciuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ciuxq-pinctrl.dtsi
@@ -358,6 +358,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};

--- a/dts/st/u5/stm32u585oiyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585oiyxq-pinctrl.dtsi
@@ -863,6 +863,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -881,6 +885,42 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u585qiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585qiix-pinctrl.dtsi
@@ -1423,6 +1423,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1441,6 +1445,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u585qiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585qiixq-pinctrl.dtsi
@@ -1373,6 +1373,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1391,6 +1395,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u585ritx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ritx-pinctrl.dtsi
@@ -639,6 +639,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -657,6 +661,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u585ritxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ritxq-pinctrl.dtsi
@@ -487,6 +487,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -505,6 +509,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u585vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585vitx-pinctrl.dtsi
@@ -1063,6 +1063,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1081,6 +1085,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u585vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585vitxq-pinctrl.dtsi
@@ -1027,6 +1027,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1045,6 +1049,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u585zitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585zitx-pinctrl.dtsi
@@ -1441,6 +1441,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1459,6 +1463,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u585zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585zitxq-pinctrl.dtsi
@@ -1416,6 +1416,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1434,6 +1438,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595aihx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595aihx-pinctrl.dtsi
@@ -1823,6 +1823,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1841,6 +1845,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595aihxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595aihxq-pinctrl.dtsi
@@ -1787,6 +1787,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1805,6 +1809,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595ajhx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595ajhx-pinctrl.dtsi
@@ -1823,6 +1823,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1841,6 +1845,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595ajhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595ajhxq-pinctrl.dtsi
@@ -1787,6 +1787,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1805,6 +1809,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595qiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595qiix-pinctrl.dtsi
@@ -1552,6 +1552,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1570,6 +1574,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595qiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595qiixq-pinctrl.dtsi
@@ -1502,6 +1502,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1520,6 +1524,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595qjix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595qjix-pinctrl.dtsi
@@ -1552,6 +1552,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1570,6 +1574,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595qjixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595qjixq-pinctrl.dtsi
@@ -1502,6 +1502,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1520,6 +1524,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595ritx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595ritx-pinctrl.dtsi
@@ -707,6 +707,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -725,6 +729,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595ritxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595ritxq-pinctrl.dtsi
@@ -547,6 +547,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -565,6 +569,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595rjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595rjtx-pinctrl.dtsi
@@ -707,6 +707,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -725,6 +729,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595rjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595rjtxq-pinctrl.dtsi
@@ -547,6 +547,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -565,6 +569,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595vitx-pinctrl.dtsi
@@ -1180,6 +1180,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1198,6 +1202,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595vitxq-pinctrl.dtsi
@@ -1126,6 +1126,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1144,6 +1148,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595vjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595vjtx-pinctrl.dtsi
@@ -1180,6 +1180,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1198,6 +1202,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595vjtxq-pinctrl.dtsi
@@ -1126,6 +1126,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1144,6 +1148,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595zitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595zitx-pinctrl.dtsi
@@ -1570,6 +1570,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1588,6 +1592,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595zitxq-pinctrl.dtsi
@@ -1527,6 +1527,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1545,6 +1549,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595ziyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595ziyxq-pinctrl.dtsi
@@ -1590,6 +1590,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1608,6 +1612,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595zjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595zjtx-pinctrl.dtsi
@@ -1570,6 +1570,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1588,6 +1592,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595zjtxq-pinctrl.dtsi
@@ -1527,6 +1527,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1545,6 +1549,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u595zjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595zjyxq-pinctrl.dtsi
@@ -1590,6 +1590,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1608,6 +1612,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u599bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599bjyxq-pinctrl.dtsi
@@ -1971,6 +1971,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1989,6 +1993,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u599nihxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599nihxq-pinctrl.dtsi
@@ -2044,6 +2044,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -2062,6 +2066,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u599njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599njhxq-pinctrl.dtsi
@@ -2044,6 +2044,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -2062,6 +2066,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u599vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599vitxq-pinctrl.dtsi
@@ -1126,6 +1126,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1144,6 +1148,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u599vjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599vjtx-pinctrl.dtsi
@@ -1180,6 +1180,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1198,6 +1202,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u599vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599vjtxq-pinctrl.dtsi
@@ -1126,6 +1126,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1144,6 +1148,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u599zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599zitxq-pinctrl.dtsi
@@ -1527,6 +1527,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1545,6 +1549,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u599ziyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599ziyxq-pinctrl.dtsi
@@ -1504,6 +1504,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1522,6 +1526,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u599zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599zjtxq-pinctrl.dtsi
@@ -1527,6 +1527,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1545,6 +1549,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u599zjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599zjyxq-pinctrl.dtsi
@@ -1504,6 +1504,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1522,6 +1526,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5a5ajhx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5ajhx-pinctrl.dtsi
@@ -1823,6 +1823,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1841,6 +1845,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5a5ajhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5ajhxq-pinctrl.dtsi
@@ -1787,6 +1787,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1805,6 +1809,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5a5qiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5qiixq-pinctrl.dtsi
@@ -1502,6 +1502,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1520,6 +1524,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5a5qjix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5qjix-pinctrl.dtsi
@@ -1552,6 +1552,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1570,6 +1574,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5a5qjixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5qjixq-pinctrl.dtsi
@@ -1502,6 +1502,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1520,6 +1524,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5a5rjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5rjtx-pinctrl.dtsi
@@ -707,6 +707,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -725,6 +729,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5a5rjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5rjtxq-pinctrl.dtsi
@@ -547,6 +547,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -565,6 +569,26 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5a5vjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5vjtx-pinctrl.dtsi
@@ -1180,6 +1180,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1198,6 +1202,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5a5vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5vjtxq-pinctrl.dtsi
@@ -1126,6 +1126,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1144,6 +1148,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5a5zjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5zjtx-pinctrl.dtsi
@@ -1570,6 +1570,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1588,6 +1592,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5a5zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5zjtxq-pinctrl.dtsi
@@ -1527,6 +1527,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1545,6 +1549,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5a5zjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5zjyxq-pinctrl.dtsi
@@ -1590,6 +1590,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1608,6 +1612,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5a9bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9bjyxq-pinctrl.dtsi
@@ -1971,6 +1971,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1989,6 +1993,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5a9njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9njhxq-pinctrl.dtsi
@@ -2044,6 +2044,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -2062,6 +2066,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5a9vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9vjtxq-pinctrl.dtsi
@@ -1126,6 +1126,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1144,6 +1148,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5a9zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9zjtxq-pinctrl.dtsi
@@ -1527,6 +1527,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1545,6 +1549,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5a9zjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9zjyxq-pinctrl.dtsi
@@ -1504,6 +1504,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1522,6 +1526,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5f7vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f7vitx-pinctrl.dtsi
@@ -1158,6 +1158,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1176,6 +1180,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5f7vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f7vitxq-pinctrl.dtsi
@@ -1104,6 +1104,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1122,6 +1126,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5f7vjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f7vjtx-pinctrl.dtsi
@@ -1158,6 +1158,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1176,6 +1180,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5f7vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f7vjtxq-pinctrl.dtsi
@@ -1104,6 +1104,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1122,6 +1126,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5f9bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9bjyxq-pinctrl.dtsi
@@ -1933,6 +1933,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1951,6 +1955,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5f9njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9njhxq-pinctrl.dtsi
@@ -2006,6 +2006,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -2024,6 +2028,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5f9vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9vitxq-pinctrl.dtsi
@@ -887,6 +887,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -905,6 +909,22 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5f9vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9vjtxq-pinctrl.dtsi
@@ -887,6 +887,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -905,6 +909,22 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5f9zijxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zijxq-pinctrl.dtsi
@@ -1429,6 +1429,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1447,6 +1451,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5f9zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zitxq-pinctrl.dtsi
@@ -1429,6 +1429,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1447,6 +1451,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5f9zjjxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zjjxq-pinctrl.dtsi
@@ -1429,6 +1429,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1447,6 +1451,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5f9zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zjtxq-pinctrl.dtsi
@@ -1429,6 +1429,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1447,6 +1451,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5g7vjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g7vjtx-pinctrl.dtsi
@@ -1186,6 +1186,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1204,6 +1208,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5g7vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g7vjtxq-pinctrl.dtsi
@@ -1132,6 +1132,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1150,6 +1154,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5g9bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9bjyxq-pinctrl.dtsi
@@ -1933,6 +1933,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1951,6 +1955,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5g9njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9njhxq-pinctrl.dtsi
@@ -2050,6 +2050,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -2068,6 +2072,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5g9vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9vjtxq-pinctrl.dtsi
@@ -923,6 +923,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -941,6 +945,22 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5g9zjjxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9zjjxq-pinctrl.dtsi
@@ -1465,6 +1465,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1483,6 +1487,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/u5/stm32u5g9zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9zjtxq-pinctrl.dtsi
@@ -1465,6 +1465,10 @@
 
 	/* JTAG PORT */
 
+	/omit-if-no-ref/ debug_traceclk_pa8: debug_traceclk_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF12)>;
+	};
+
 	/omit-if-no-ref/ debug_jtms_swdio_pa13: debug_jtms_swdio_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF0)>;
 	};
@@ -1483,6 +1487,46 @@
 
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pc9: debug_traced0_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc10: debug_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe2: debug_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
@@ -505,6 +505,14 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb55revx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55revx-pinctrl.dtsi
@@ -505,6 +505,14 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
@@ -505,6 +505,14 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
@@ -597,6 +597,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pd9: sys_traced0_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
@@ -597,6 +597,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pd9: sys_traced0_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
@@ -597,6 +597,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pd9: sys_traced0_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
@@ -597,6 +597,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pd9: sys_traced0_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
@@ -597,6 +597,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pd9: sys_traced0_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
@@ -597,6 +597,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pd9: sys_traced0_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb55vyyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vyyx-pinctrl.dtsi
@@ -597,6 +597,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pd9: sys_traced0_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
@@ -589,6 +589,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ sys_traced1_pc10: sys_traced1_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced3_pc12: sys_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced2_pd2: sys_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traced0_pd9: sys_traced0_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF0)>;
+	};
+
+	/omit-if-no-ref/ sys_traceclk_pe2: sys_traceclk_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wba/stm32wba23ceux-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba23ceux-pinctrl.dtsi
@@ -232,12 +232,32 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pa15: debug_traced0_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb3: debug_traced1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF6)>;
+	};
+
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb4: debug_traced2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb5: debug_traced3_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF6)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb6: debug_traceclk_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/wba/stm32wba23keux-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba23keux-pinctrl.dtsi
@@ -180,12 +180,24 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pa15: debug_traced0_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb3: debug_traced1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF6)>;
+	};
+
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb4: debug_traced2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/wba/stm32wba25ceux-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba25ceux-pinctrl.dtsi
@@ -224,12 +224,32 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pa15: debug_traced0_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb3: debug_traced1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF6)>;
+	};
+
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb4: debug_traced2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pb5: debug_traced3_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF6)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pb6: debug_traceclk_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 	};
 
 	/* LPTIM */
@@ -618,6 +638,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF3)>;
 	};
@@ -628,6 +652,48 @@
 
 	/omit-if-no-ref/ usb_dm_pb9: usb_dm_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+	};
+
+	/* XSPI */
+
+	/omit-if-no-ref/ xspi1_dqs_pa2: xspi1_dqs_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF10)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ xspi1_clk_pa15: xspi1_clk_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF13)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ xspi1_io0_pb3: xspi1_io0_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF13)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ xspi1_io1_pb4: xspi1_io1_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ xspi1_io2_pb5: xspi1_io2_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF10)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ xspi1_io3_pb6: xspi1_io3_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF10)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ xspi1_io2_pb8: xspi1_io2_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ xspi1_io3_pb9: xspi1_io3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+		slew-rate = "very-high-speed";
 	};
 
 };

--- a/dts/st/wba/stm32wba25hefx-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba25hefx-pinctrl.dtsi
@@ -138,12 +138,24 @@
 		pinmux = <STM32_PINMUX('A', 15, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pa15: debug_traced0_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF6)>;
+	};
+
 	/omit-if-no-ref/ debug_jtdo_swo_pb3: debug_jtdo_swo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced1_pb3: debug_traced1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF6)>;
+	};
+
 	/omit-if-no-ref/ debug_njtrst_pb4: debug_njtrst_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pb4: debug_traced2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 	};
 
 	/* LPTIM */
@@ -388,6 +400,10 @@
 
 	/* USB */
 
+	/omit-if-no-ref/ usb_sof_pa8: usb_sof_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF10)>;
+	};
+
 	/omit-if-no-ref/ usb_noe_pa13: usb_noe_pa13 {
 		pinmux = <STM32_PINMUX('A', 13, AF3)>;
 	};
@@ -398,6 +414,33 @@
 
 	/omit-if-no-ref/ usb_dm_pb9: usb_dm_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+	};
+
+	/* XSPI */
+
+	/omit-if-no-ref/ xspi1_clk_pa15: xspi1_clk_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF13)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ xspi1_io0_pb3: xspi1_io0_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF13)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ xspi1_io1_pb4: xspi1_io1_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ xspi1_io2_pb8: xspi1_io2_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ xspi1_io3_pb9: xspi1_io3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+		slew-rate = "very-high-speed";
 	};
 
 };

--- a/dts/st/wba/stm32wba62mgfx-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba62mgfx-pinctrl.dtsi
@@ -440,6 +440,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced3_pd14: debug_traced3_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe0: debug_traceclk_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe1: debug_traced0_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe2: debug_traced1_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe3: debug_traced2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pa0: lptim1_in1_pa0 {

--- a/dts/st/wba/stm32wba62mifx-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba62mifx-pinctrl.dtsi
@@ -440,6 +440,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced3_pd14: debug_traced3_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe0: debug_traceclk_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe1: debug_traced0_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe2: debug_traced1_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe3: debug_traced2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pa0: lptim1_in1_pa0 {

--- a/dts/st/wba/stm32wba62pgix-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba62pgix-pinctrl.dtsi
@@ -619,6 +619,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced3_pd14: debug_traced3_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe0: debug_traceclk_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe1: debug_traced0_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe2: debug_traced1_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe3: debug_traced2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pa0: lptim1_in1_pa0 {

--- a/dts/st/wba/stm32wba62piix-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba62piix-pinctrl.dtsi
@@ -619,6 +619,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced3_pd14: debug_traced3_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe0: debug_traceclk_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe1: debug_traced0_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe2: debug_traced1_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe3: debug_traced2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pa0: lptim1_in1_pa0 {

--- a/dts/st/wba/stm32wba65mgfx-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba65mgfx-pinctrl.dtsi
@@ -440,6 +440,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced3_pd14: debug_traced3_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe0: debug_traceclk_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe1: debug_traced0_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe2: debug_traced1_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe3: debug_traced2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pa0: lptim1_in1_pa0 {

--- a/dts/st/wba/stm32wba65mifx-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba65mifx-pinctrl.dtsi
@@ -440,6 +440,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced3_pd14: debug_traced3_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe0: debug_traceclk_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe1: debug_traced0_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe2: debug_traced1_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe3: debug_traced2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pa0: lptim1_in1_pa0 {

--- a/dts/st/wba/stm32wba65pgix-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba65pgix-pinctrl.dtsi
@@ -619,6 +619,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced3_pd14: debug_traced3_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe0: debug_traceclk_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe1: debug_traced0_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe2: debug_traced1_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe3: debug_traced2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pa0: lptim1_in1_pa0 {

--- a/dts/st/wba/stm32wba65piix-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba65piix-pinctrl.dtsi
@@ -619,6 +619,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced3_pd14: debug_traced3_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe0: debug_traceclk_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe1: debug_traced0_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe2: debug_traced1_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe3: debug_traced2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pa0: lptim1_in1_pa0 {

--- a/dts/st/wba/stm32wba65rgvx-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba65rgvx-pinctrl.dtsi
@@ -396,6 +396,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced3_pd14: debug_traced3_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe0: debug_traceclk_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe1: debug_traced0_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe2: debug_traced1_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe3: debug_traced2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pa0: lptim1_in1_pa0 {

--- a/dts/st/wba/stm32wba65rivx-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba65rivx-pinctrl.dtsi
@@ -396,6 +396,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced3_pd14: debug_traced3_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe0: debug_traceclk_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe1: debug_traced0_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe2: debug_traced1_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe3: debug_traced2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pa0: lptim1_in1_pa0 {

--- a/dts/st/wba/stm32wba6moihx-pinctrl.dtsi
+++ b/dts/st/wba/stm32wba6moihx-pinctrl.dtsi
@@ -440,6 +440,26 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced3_pd14: debug_traced3_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traceclk_pe0: debug_traceclk_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe1: debug_traced0_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe2: debug_traced1_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe3: debug_traced2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_in1_pa0: lptim1_in1_pa0 {

--- a/scripts/genpinctrl/genpinctrl.py
+++ b/scripts/genpinctrl/genpinctrl.py
@@ -17,7 +17,7 @@ import logging
 from pathlib import Path
 import re
 import shutil
-from subprocess import check_output, STDOUT, CalledProcessError
+from subprocess import check_output, STDOUT, CalledProcessError, run
 import xml.etree.ElementTree as ET
 
 from jinja2 import Environment, FileSystemLoader
@@ -77,6 +77,11 @@ SUPPORTED_FAMILIES = [
     "stm32wl",
 ]
 """Supported SoC families"""
+
+HAL2_FAMILIES = [
+    "stm32c5",
+]
+"""SoC families relying on HAL2"""
 
 PIN_MODS = [
     "_C",  # Pins with analog switch (H7)
@@ -616,6 +621,13 @@ def main(data_path, output):
     if output.exists() and not FAMILY_FILTER.is_active():
         shutil.rmtree(output)
         output.mkdir(parents=True)
+        # Do not consider SoCs related to HAL2
+        for family in HAL2_FAMILIES:
+            family_path = output / "st" / family.removeprefix("stm32")
+            try:
+                run(["git", "checkout", "--", family_path], check=True)
+            except CalledProcessError:
+                break
 
     for family, refs in mcu_signals.items():
         # check family is supported


### PR DESCRIPTION
Update generated pinctrl DTSI files that was wrongly updated by commit de30f8721b26 that was rebased without re-generating the DTSI file while previously merged commit 1622efd17c8d0 added generation of pinctrl nodes related to I2S, JTAG TRACECLK, USB SOF for HAL1 based SoCs as well as a modification of the XSPIM pinctrl nodes heading inline comment.

Prevent Git from tracking removal on pinctrl sub-directories for SoCs relying on HAL2 (currently only the stm32c5 SoC family) when using **genpinctrl.py** scirpt.
