### PR TITLE
add MDF support

### DIFF
--- a/dts/st/h5/stm32h5e4ajix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4ajix-pinctrl.dtsi
@@ -3674,6 +3674,168 @@
 		pinmux = <STM32_PINMUX('I', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e4ajixq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4ajixq-pinctrl.dtsi
@@ -3590,6 +3590,168 @@
 		pinmux = <STM32_PINMUX('I', 5, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e4akix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4akix-pinctrl.dtsi
@@ -3674,6 +3674,168 @@
 		pinmux = <STM32_PINMUX('I', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e4ijkx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4ijkx-pinctrl.dtsi
@@ -3731,6 +3731,168 @@
 		pinmux = <STM32_PINMUX('I', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e4ijkxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4ijkxq-pinctrl.dtsi
@@ -3714,6 +3714,168 @@
 		pinmux = <STM32_PINMUX('I', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e4ijtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4ijtx-pinctrl.dtsi
@@ -3731,6 +3731,168 @@
 		pinmux = <STM32_PINMUX('I', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e4ijtxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4ijtxq-pinctrl.dtsi
@@ -3663,6 +3663,163 @@
 		pinmux = <STM32_PINMUX('I', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e4ikkx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4ikkx-pinctrl.dtsi
@@ -3731,6 +3731,168 @@
 		pinmux = <STM32_PINMUX('I', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e4iktx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4iktx-pinctrl.dtsi
@@ -3731,6 +3731,168 @@
 		pinmux = <STM32_PINMUX('I', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e4vjtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4vjtx-pinctrl.dtsi
@@ -2347,6 +2347,98 @@
 		pinmux = <STM32_PINMUX('E', 15, AF11)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e4vjtxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4vjtxq-pinctrl.dtsi
@@ -2268,6 +2268,88 @@
 		pinmux = <STM32_PINMUX('E', 15, AF11)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e4vktx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4vktx-pinctrl.dtsi
@@ -2347,6 +2347,98 @@
 		pinmux = <STM32_PINMUX('E', 15, AF11)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e4zjjx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4zjjx-pinctrl.dtsi
@@ -3186,6 +3186,128 @@
 		pinmux = <STM32_PINMUX('G', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e4zjjxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4zjjxq-pinctrl.dtsi
@@ -3117,6 +3117,128 @@
 		pinmux = <STM32_PINMUX('G', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e4zjtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4zjtx-pinctrl.dtsi
@@ -3147,6 +3147,128 @@
 		pinmux = <STM32_PINMUX('G', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e4zjtxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4zjtxq-pinctrl.dtsi
@@ -3065,6 +3065,118 @@
 		pinmux = <STM32_PINMUX('G', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e4zkjx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4zkjx-pinctrl.dtsi
@@ -2572,6 +2572,128 @@
 		pinmux = <STM32_PINMUX('G', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e4zktx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e4zktx-pinctrl.dtsi
@@ -2539,6 +2539,128 @@
 		pinmux = <STM32_PINMUX('G', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e5ijkxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e5ijkxq-pinctrl.dtsi
@@ -3714,6 +3714,168 @@
 		pinmux = <STM32_PINMUX('I', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e5ijtxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e5ijtxq-pinctrl.dtsi
@@ -3545,6 +3545,163 @@
 		pinmux = <STM32_PINMUX('I', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e5ikkxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e5ikkxq-pinctrl.dtsi
@@ -3714,6 +3714,168 @@
 		pinmux = <STM32_PINMUX('I', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e5iktxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e5iktxq-pinctrl.dtsi
@@ -3545,6 +3545,163 @@
 		pinmux = <STM32_PINMUX('I', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e5ljhxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e5ljhxq-pinctrl.dtsi
@@ -4125,6 +4125,228 @@
 		pinmux = <STM32_PINMUX('K', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi12: mdf1_cki5_pi12 {
+		pinmux = <STM32_PINMUX('I', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi13: mdf1_sdi5_pi13 {
+		pinmux = <STM32_PINMUX('I', 13, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pj0: mdf1_cki1_pj0 {
+		pinmux = <STM32_PINMUX('J', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pj1: mdf1_sdi1_pj1 {
+		pinmux = <STM32_PINMUX('J', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pj2: mdf1_cck0_pj2 {
+		pinmux = <STM32_PINMUX('J', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pj3: mdf1_sdi4_pj3 {
+		pinmux = <STM32_PINMUX('J', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pj4: mdf1_cck1_pj4 {
+		pinmux = <STM32_PINMUX('J', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pj8: mdf1_cki4_pj8 {
+		pinmux = <STM32_PINMUX('J', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pj12: mdf1_cki0_pj12 {
+		pinmux = <STM32_PINMUX('J', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pj13: mdf1_sdi0_pj13 {
+		pinmux = <STM32_PINMUX('J', 13, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pk0: mdf1_sdi2_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pk1: mdf1_cki2_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e5lkhxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e5lkhxq-pinctrl.dtsi
@@ -4125,6 +4125,228 @@
 		pinmux = <STM32_PINMUX('K', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi12: mdf1_cki5_pi12 {
+		pinmux = <STM32_PINMUX('I', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi13: mdf1_sdi5_pi13 {
+		pinmux = <STM32_PINMUX('I', 13, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pj0: mdf1_cki1_pj0 {
+		pinmux = <STM32_PINMUX('J', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pj1: mdf1_sdi1_pj1 {
+		pinmux = <STM32_PINMUX('J', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pj2: mdf1_cck0_pj2 {
+		pinmux = <STM32_PINMUX('J', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pj3: mdf1_sdi4_pj3 {
+		pinmux = <STM32_PINMUX('J', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pj4: mdf1_cck1_pj4 {
+		pinmux = <STM32_PINMUX('J', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pj8: mdf1_cki4_pj8 {
+		pinmux = <STM32_PINMUX('J', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pj12: mdf1_cki0_pj12 {
+		pinmux = <STM32_PINMUX('J', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pj13: mdf1_sdi0_pj13 {
+		pinmux = <STM32_PINMUX('J', 13, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pk0: mdf1_sdi2_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pk1: mdf1_cki2_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e5vjyxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e5vjyxq-pinctrl.dtsi
@@ -2266,6 +2266,88 @@
 		pinmux = <STM32_PINMUX('E', 15, AF11)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e5vkyxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e5vkyxq-pinctrl.dtsi
@@ -2266,6 +2266,88 @@
 		pinmux = <STM32_PINMUX('E', 15, AF11)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e5zjtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e5zjtx-pinctrl.dtsi
@@ -3029,6 +3029,128 @@
 		pinmux = <STM32_PINMUX('G', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5e5zktx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5e5zktx-pinctrl.dtsi
@@ -2469,6 +2469,128 @@
 		pinmux = <STM32_PINMUX('G', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5f4ajix-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4ajix-pinctrl.dtsi
@@ -3674,6 +3674,168 @@
 		pinmux = <STM32_PINMUX('I', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5f4ajixq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4ajixq-pinctrl.dtsi
@@ -3590,6 +3590,168 @@
 		pinmux = <STM32_PINMUX('I', 5, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5f4ijkx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4ijkx-pinctrl.dtsi
@@ -3731,6 +3731,168 @@
 		pinmux = <STM32_PINMUX('I', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5f4ijkxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4ijkxq-pinctrl.dtsi
@@ -3714,6 +3714,168 @@
 		pinmux = <STM32_PINMUX('I', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5f4ijtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4ijtx-pinctrl.dtsi
@@ -3731,6 +3731,168 @@
 		pinmux = <STM32_PINMUX('I', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5f4ijtxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4ijtxq-pinctrl.dtsi
@@ -3663,6 +3663,163 @@
 		pinmux = <STM32_PINMUX('I', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5f4vjtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4vjtx-pinctrl.dtsi
@@ -2347,6 +2347,98 @@
 		pinmux = <STM32_PINMUX('E', 15, AF11)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5f4vjtxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4vjtxq-pinctrl.dtsi
@@ -2268,6 +2268,88 @@
 		pinmux = <STM32_PINMUX('E', 15, AF11)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5f4zjjx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4zjjx-pinctrl.dtsi
@@ -3186,6 +3186,128 @@
 		pinmux = <STM32_PINMUX('G', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5f4zjjxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4zjjxq-pinctrl.dtsi
@@ -3117,6 +3117,128 @@
 		pinmux = <STM32_PINMUX('G', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5f4zjtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4zjtx-pinctrl.dtsi
@@ -3147,6 +3147,128 @@
 		pinmux = <STM32_PINMUX('G', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5f4zjtxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f4zjtxq-pinctrl.dtsi
@@ -3065,6 +3065,118 @@
 		pinmux = <STM32_PINMUX('G', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5f5ijkxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f5ijkxq-pinctrl.dtsi
@@ -3714,6 +3714,168 @@
 		pinmux = <STM32_PINMUX('I', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5f5ijtxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f5ijtxq-pinctrl.dtsi
@@ -3545,6 +3545,163 @@
 		pinmux = <STM32_PINMUX('I', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5f5ljhxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f5ljhxq-pinctrl.dtsi
@@ -4125,6 +4125,228 @@
 		pinmux = <STM32_PINMUX('K', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_ph2: mdf1_cki2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_ph3: mdf1_sdi2_ph3 {
+		pinmux = <STM32_PINMUX('H', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_ph14: mdf1_cki3_ph14 {
+		pinmux = <STM32_PINMUX('H', 14, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_ph15: mdf1_sdi3_ph15 {
+		pinmux = <STM32_PINMUX('H', 15, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pi1: mdf1_cki4_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pi2: mdf1_sdi4_pi2 {
+		pinmux = <STM32_PINMUX('I', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi6: mdf1_cki5_pi6 {
+		pinmux = <STM32_PINMUX('I', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi7: mdf1_sdi5_pi7 {
+		pinmux = <STM32_PINMUX('I', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pi12: mdf1_cki5_pi12 {
+		pinmux = <STM32_PINMUX('I', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pi13: mdf1_sdi5_pi13 {
+		pinmux = <STM32_PINMUX('I', 13, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pj0: mdf1_cki1_pj0 {
+		pinmux = <STM32_PINMUX('J', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pj1: mdf1_sdi1_pj1 {
+		pinmux = <STM32_PINMUX('J', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pj2: mdf1_cck0_pj2 {
+		pinmux = <STM32_PINMUX('J', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pj3: mdf1_sdi4_pj3 {
+		pinmux = <STM32_PINMUX('J', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pj4: mdf1_cck1_pj4 {
+		pinmux = <STM32_PINMUX('J', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pj8: mdf1_cki4_pj8 {
+		pinmux = <STM32_PINMUX('J', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pj12: mdf1_cki0_pj12 {
+		pinmux = <STM32_PINMUX('J', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pj13: mdf1_sdi0_pj13 {
+		pinmux = <STM32_PINMUX('J', 13, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pk0: mdf1_sdi2_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pk1: mdf1_cki2_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5f5vjyxq-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f5vjyxq-pinctrl.dtsi
@@ -2266,6 +2266,88 @@
 		pinmux = <STM32_PINMUX('E', 15, AF11)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/h5/stm32h5f5zjtx-pinctrl.dtsi
+++ b/dts/st/h5/stm32h5f5zjtx-pinctrl.dtsi
@@ -3029,6 +3029,128 @@
 		pinmux = <STM32_PINMUX('G', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc1: mdf1_sdi1_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc3: mdf1_sdi3_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pc4: mdf1_cck0_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc5: mdf1_sdi3_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd4: mdf1_cki3_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe4: mdf1_sdi2_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pe5: mdf1_cck1_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pe6: mdf1_sdi1_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pf7: mdf1_cki1_pf7 {
+		pinmux = <STM32_PINMUX('F', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf9: mdf1_cck0_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pg4: mdf1_cki0_pg4 {
+		pinmux = <STM32_PINMUX('G', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pg5: mdf1_sdi0_pg5 {
+		pinmux = <STM32_PINMUX('G', 5, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pg7: mdf1_cck1_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF8)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {

--- a/dts/st/mp2/stm32mp211aalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211aalx-pinctrl.dtsi
@@ -2499,6 +2499,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp211aamx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211aamx-pinctrl.dtsi
@@ -2499,6 +2499,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp211aanx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211aanx-pinctrl.dtsi
@@ -2499,6 +2499,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp211aaox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211aaox-pinctrl.dtsi
@@ -2094,6 +2094,93 @@
 		pinmux = <STM32_PINMUX('F', 1, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp211calx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211calx-pinctrl.dtsi
@@ -2467,6 +2467,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp211camx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211camx-pinctrl.dtsi
@@ -2467,6 +2467,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp211canx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211canx-pinctrl.dtsi
@@ -2467,6 +2467,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp211caox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211caox-pinctrl.dtsi
@@ -2094,6 +2094,93 @@
 		pinmux = <STM32_PINMUX('F', 1, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp211dalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211dalx-pinctrl.dtsi
@@ -2467,6 +2467,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp211damx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211damx-pinctrl.dtsi
@@ -2467,6 +2467,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp211danx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211danx-pinctrl.dtsi
@@ -2467,6 +2467,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp211daox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211daox-pinctrl.dtsi
@@ -2094,6 +2094,93 @@
 		pinmux = <STM32_PINMUX('F', 1, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp211falx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211falx-pinctrl.dtsi
@@ -2467,6 +2467,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp211famx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211famx-pinctrl.dtsi
@@ -2467,6 +2467,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp211fanx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211fanx-pinctrl.dtsi
@@ -2467,6 +2467,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp211faox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp211faox-pinctrl.dtsi
@@ -2094,6 +2094,93 @@
 		pinmux = <STM32_PINMUX('F', 1, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp213aalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213aalx-pinctrl.dtsi
@@ -2846,6 +2846,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp213aamx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213aamx-pinctrl.dtsi
@@ -2846,6 +2846,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp213aanx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213aanx-pinctrl.dtsi
@@ -2846,6 +2846,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp213aaox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213aaox-pinctrl.dtsi
@@ -2437,6 +2437,93 @@
 		pinmux = <STM32_PINMUX('F', 1, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp213calx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213calx-pinctrl.dtsi
@@ -2846,6 +2846,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp213camx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213camx-pinctrl.dtsi
@@ -2846,6 +2846,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp213canx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213canx-pinctrl.dtsi
@@ -2846,6 +2846,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp213caox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213caox-pinctrl.dtsi
@@ -2437,6 +2437,93 @@
 		pinmux = <STM32_PINMUX('F', 1, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp213dalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213dalx-pinctrl.dtsi
@@ -2846,6 +2846,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp213damx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213damx-pinctrl.dtsi
@@ -2846,6 +2846,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp213danx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213danx-pinctrl.dtsi
@@ -2846,6 +2846,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp213daox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213daox-pinctrl.dtsi
@@ -2437,6 +2437,93 @@
 		pinmux = <STM32_PINMUX('F', 1, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp213falx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213falx-pinctrl.dtsi
@@ -2846,6 +2846,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp213famx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213famx-pinctrl.dtsi
@@ -2846,6 +2846,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp213fanx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213fanx-pinctrl.dtsi
@@ -2846,6 +2846,108 @@
 		pinmux = <STM32_PINMUX('Z', 1, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp213faox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp213faox-pinctrl.dtsi
@@ -2437,6 +2437,93 @@
 		pinmux = <STM32_PINMUX('F', 1, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp215aalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215aalx-pinctrl.dtsi
@@ -3060,6 +3060,108 @@
 		pinmux = <STM32_PINMUX('I', 6, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp215aamx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215aamx-pinctrl.dtsi
@@ -3060,6 +3060,108 @@
 		pinmux = <STM32_PINMUX('I', 6, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp215aanx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215aanx-pinctrl.dtsi
@@ -3060,6 +3060,108 @@
 		pinmux = <STM32_PINMUX('I', 6, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp215aaox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215aaox-pinctrl.dtsi
@@ -2619,6 +2619,93 @@
 		pinmux = <STM32_PINMUX('I', 4, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp215calx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215calx-pinctrl.dtsi
@@ -3060,6 +3060,108 @@
 		pinmux = <STM32_PINMUX('I', 6, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp215camx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215camx-pinctrl.dtsi
@@ -3060,6 +3060,108 @@
 		pinmux = <STM32_PINMUX('I', 6, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp215canx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215canx-pinctrl.dtsi
@@ -3060,6 +3060,108 @@
 		pinmux = <STM32_PINMUX('I', 6, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp215caox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215caox-pinctrl.dtsi
@@ -2619,6 +2619,93 @@
 		pinmux = <STM32_PINMUX('I', 4, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp215dalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215dalx-pinctrl.dtsi
@@ -3060,6 +3060,108 @@
 		pinmux = <STM32_PINMUX('I', 6, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp215damx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215damx-pinctrl.dtsi
@@ -3060,6 +3060,108 @@
 		pinmux = <STM32_PINMUX('I', 6, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp215danx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215danx-pinctrl.dtsi
@@ -3060,6 +3060,108 @@
 		pinmux = <STM32_PINMUX('I', 6, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp215daox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215daox-pinctrl.dtsi
@@ -2619,6 +2619,93 @@
 		pinmux = <STM32_PINMUX('I', 4, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp215falx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215falx-pinctrl.dtsi
@@ -3060,6 +3060,108 @@
 		pinmux = <STM32_PINMUX('I', 6, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp215famx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215famx-pinctrl.dtsi
@@ -3060,6 +3060,108 @@
 		pinmux = <STM32_PINMUX('I', 6, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp215fanx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215fanx-pinctrl.dtsi
@@ -3060,6 +3060,108 @@
 		pinmux = <STM32_PINMUX('I', 6, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pz3: mdf1_sdi3_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp215faox-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp215faox-pinctrl.dtsi
@@ -2619,6 +2619,93 @@
 		pinmux = <STM32_PINMUX('I', 4, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs2_pb11: octospi1_ncs2_pb11 {

--- a/dts/st/mp2/stm32mp231aajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231aajx-pinctrl.dtsi
@@ -2993,6 +2993,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp231aakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231aakx-pinctrl.dtsi
@@ -2993,6 +2993,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp231aalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231aalx-pinctrl.dtsi
@@ -2993,6 +2993,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp231cajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231cajx-pinctrl.dtsi
@@ -2993,6 +2993,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp231cakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231cakx-pinctrl.dtsi
@@ -2993,6 +2993,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp231calx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231calx-pinctrl.dtsi
@@ -2993,6 +2993,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp231dajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231dajx-pinctrl.dtsi
@@ -2993,6 +2993,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp231dakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231dakx-pinctrl.dtsi
@@ -2993,6 +2993,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp231dalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231dalx-pinctrl.dtsi
@@ -2993,6 +2993,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp231fajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231fajx-pinctrl.dtsi
@@ -2993,6 +2993,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp231fakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231fakx-pinctrl.dtsi
@@ -2993,6 +2993,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp231falx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp231falx-pinctrl.dtsi
@@ -2993,6 +2993,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp233aajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233aajx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp233aakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233aakx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp233aalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233aalx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp233cajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233cajx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp233cakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233cakx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp233calx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233calx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp233dajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233dajx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp233dakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233dakx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp233dalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233dalx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp233fajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233fajx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp233fakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233fakx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp233falx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp233falx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp235aajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235aajx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp235aakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235aakx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp235aalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235aalx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp235cajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235cajx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp235cakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235cakx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp235calx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235calx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp235dajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235dajx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp235dakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235dakx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp235dalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235dalx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp235fajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235fajx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp235fakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235fakx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp235falx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp235falx-pinctrl.dtsi
@@ -3348,6 +3348,118 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp251aaix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251aaix-pinctrl.dtsi
@@ -3750,6 +3750,273 @@
 		pinmux = <STM32_PINMUX('J', 15, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pi14: mdf1_sdi1_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pi15: mdf1_cki2_pi15 {
+		pinmux = <STM32_PINMUX('I', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pj4: mdf1_cck1_pj4 {
+		pinmux = <STM32_PINMUX('J', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pk0: mdf1_cck0_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pk1: mdf1_sdi2_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pk3: mdf1_cki1_pk3 {
+		pinmux = <STM32_PINMUX('K', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pk5: mdf1_cki0_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pk7: mdf1_sdi0_pk7 {
+		pinmux = <STM32_PINMUX('K', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp251aajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251aajx-pinctrl.dtsi
@@ -3183,6 +3183,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp251aakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251aakx-pinctrl.dtsi
@@ -3183,6 +3183,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp251aalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251aalx-pinctrl.dtsi
@@ -3183,6 +3183,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp251caix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251caix-pinctrl.dtsi
@@ -3750,6 +3750,273 @@
 		pinmux = <STM32_PINMUX('J', 15, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pi14: mdf1_sdi1_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pi15: mdf1_cki2_pi15 {
+		pinmux = <STM32_PINMUX('I', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pj4: mdf1_cck1_pj4 {
+		pinmux = <STM32_PINMUX('J', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pk0: mdf1_cck0_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pk1: mdf1_sdi2_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pk3: mdf1_cki1_pk3 {
+		pinmux = <STM32_PINMUX('K', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pk5: mdf1_cki0_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pk7: mdf1_sdi0_pk7 {
+		pinmux = <STM32_PINMUX('K', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp251cajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251cajx-pinctrl.dtsi
@@ -3183,6 +3183,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp251cakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251cakx-pinctrl.dtsi
@@ -3183,6 +3183,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp251calx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251calx-pinctrl.dtsi
@@ -3183,6 +3183,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp251daix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251daix-pinctrl.dtsi
@@ -3750,6 +3750,273 @@
 		pinmux = <STM32_PINMUX('J', 15, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pi14: mdf1_sdi1_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pi15: mdf1_cki2_pi15 {
+		pinmux = <STM32_PINMUX('I', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pj4: mdf1_cck1_pj4 {
+		pinmux = <STM32_PINMUX('J', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pk0: mdf1_cck0_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pk1: mdf1_sdi2_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pk3: mdf1_cki1_pk3 {
+		pinmux = <STM32_PINMUX('K', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pk5: mdf1_cki0_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pk7: mdf1_sdi0_pk7 {
+		pinmux = <STM32_PINMUX('K', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp251dajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251dajx-pinctrl.dtsi
@@ -3183,6 +3183,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp251dakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251dakx-pinctrl.dtsi
@@ -3183,6 +3183,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp251dalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251dalx-pinctrl.dtsi
@@ -3183,6 +3183,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp251faix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251faix-pinctrl.dtsi
@@ -3750,6 +3750,273 @@
 		pinmux = <STM32_PINMUX('J', 15, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pi14: mdf1_sdi1_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pi15: mdf1_cki2_pi15 {
+		pinmux = <STM32_PINMUX('I', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pj4: mdf1_cck1_pj4 {
+		pinmux = <STM32_PINMUX('J', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pk0: mdf1_cck0_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pk1: mdf1_sdi2_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pk3: mdf1_cki1_pk3 {
+		pinmux = <STM32_PINMUX('K', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pk5: mdf1_cki0_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pk7: mdf1_sdi0_pk7 {
+		pinmux = <STM32_PINMUX('K', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp251fajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251fajx-pinctrl.dtsi
@@ -3183,6 +3183,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp251fakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251fakx-pinctrl.dtsi
@@ -3183,6 +3183,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp251falx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp251falx-pinctrl.dtsi
@@ -3183,6 +3183,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp253aaix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253aaix-pinctrl.dtsi
@@ -4145,6 +4145,273 @@
 		pinmux = <STM32_PINMUX('J', 15, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pi14: mdf1_sdi1_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pi15: mdf1_cki2_pi15 {
+		pinmux = <STM32_PINMUX('I', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pj4: mdf1_cck1_pj4 {
+		pinmux = <STM32_PINMUX('J', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pk0: mdf1_cck0_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pk1: mdf1_sdi2_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pk3: mdf1_cki1_pk3 {
+		pinmux = <STM32_PINMUX('K', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pk5: mdf1_cki0_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pk7: mdf1_sdi0_pk7 {
+		pinmux = <STM32_PINMUX('K', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp253aajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253aajx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp253aakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253aakx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp253aalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253aalx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp253caix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253caix-pinctrl.dtsi
@@ -4145,6 +4145,273 @@
 		pinmux = <STM32_PINMUX('J', 15, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pi14: mdf1_sdi1_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pi15: mdf1_cki2_pi15 {
+		pinmux = <STM32_PINMUX('I', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pj4: mdf1_cck1_pj4 {
+		pinmux = <STM32_PINMUX('J', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pk0: mdf1_cck0_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pk1: mdf1_sdi2_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pk3: mdf1_cki1_pk3 {
+		pinmux = <STM32_PINMUX('K', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pk5: mdf1_cki0_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pk7: mdf1_sdi0_pk7 {
+		pinmux = <STM32_PINMUX('K', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp253cajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253cajx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp253cakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253cakx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp253calx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253calx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp253daix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253daix-pinctrl.dtsi
@@ -4145,6 +4145,273 @@
 		pinmux = <STM32_PINMUX('J', 15, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pi14: mdf1_sdi1_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pi15: mdf1_cki2_pi15 {
+		pinmux = <STM32_PINMUX('I', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pj4: mdf1_cck1_pj4 {
+		pinmux = <STM32_PINMUX('J', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pk0: mdf1_cck0_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pk1: mdf1_sdi2_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pk3: mdf1_cki1_pk3 {
+		pinmux = <STM32_PINMUX('K', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pk5: mdf1_cki0_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pk7: mdf1_sdi0_pk7 {
+		pinmux = <STM32_PINMUX('K', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp253dajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253dajx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp253dakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253dakx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp253dalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253dalx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp253faix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253faix-pinctrl.dtsi
@@ -4145,6 +4145,273 @@
 		pinmux = <STM32_PINMUX('J', 15, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pi14: mdf1_sdi1_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pi15: mdf1_cki2_pi15 {
+		pinmux = <STM32_PINMUX('I', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pj4: mdf1_cck1_pj4 {
+		pinmux = <STM32_PINMUX('J', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pk0: mdf1_cck0_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pk1: mdf1_sdi2_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pk3: mdf1_cki1_pk3 {
+		pinmux = <STM32_PINMUX('K', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pk5: mdf1_cki0_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pk7: mdf1_sdi0_pk7 {
+		pinmux = <STM32_PINMUX('K', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp253fajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253fajx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp253fakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253fakx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp253falx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp253falx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp255aaix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255aaix-pinctrl.dtsi
@@ -4145,6 +4145,273 @@
 		pinmux = <STM32_PINMUX('J', 15, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pi14: mdf1_sdi1_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pi15: mdf1_cki2_pi15 {
+		pinmux = <STM32_PINMUX('I', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pj4: mdf1_cck1_pj4 {
+		pinmux = <STM32_PINMUX('J', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pk0: mdf1_cck0_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pk1: mdf1_sdi2_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pk3: mdf1_cki1_pk3 {
+		pinmux = <STM32_PINMUX('K', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pk5: mdf1_cki0_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pk7: mdf1_sdi0_pk7 {
+		pinmux = <STM32_PINMUX('K', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp255aajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255aajx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp255aakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255aakx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp255aalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255aalx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp255caix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255caix-pinctrl.dtsi
@@ -4145,6 +4145,273 @@
 		pinmux = <STM32_PINMUX('J', 15, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pi14: mdf1_sdi1_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pi15: mdf1_cki2_pi15 {
+		pinmux = <STM32_PINMUX('I', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pj4: mdf1_cck1_pj4 {
+		pinmux = <STM32_PINMUX('J', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pk0: mdf1_cck0_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pk1: mdf1_sdi2_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pk3: mdf1_cki1_pk3 {
+		pinmux = <STM32_PINMUX('K', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pk5: mdf1_cki0_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pk7: mdf1_sdi0_pk7 {
+		pinmux = <STM32_PINMUX('K', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp255cajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255cajx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp255cakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255cakx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp255calx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255calx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp255daix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255daix-pinctrl.dtsi
@@ -4145,6 +4145,273 @@
 		pinmux = <STM32_PINMUX('J', 15, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pi14: mdf1_sdi1_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pi15: mdf1_cki2_pi15 {
+		pinmux = <STM32_PINMUX('I', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pj4: mdf1_cck1_pj4 {
+		pinmux = <STM32_PINMUX('J', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pk0: mdf1_cck0_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pk1: mdf1_sdi2_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pk3: mdf1_cki1_pk3 {
+		pinmux = <STM32_PINMUX('K', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pk5: mdf1_cki0_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pk7: mdf1_sdi0_pk7 {
+		pinmux = <STM32_PINMUX('K', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp255dajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255dajx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp255dakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255dakx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp255dalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255dalx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp255faix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255faix-pinctrl.dtsi
@@ -4145,6 +4145,273 @@
 		pinmux = <STM32_PINMUX('J', 15, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pi14: mdf1_sdi1_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pi15: mdf1_cki2_pi15 {
+		pinmux = <STM32_PINMUX('I', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pj4: mdf1_cck1_pj4 {
+		pinmux = <STM32_PINMUX('J', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pk0: mdf1_cck0_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pk1: mdf1_sdi2_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pk3: mdf1_cki1_pk3 {
+		pinmux = <STM32_PINMUX('K', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pk5: mdf1_cki0_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pk7: mdf1_sdi0_pk7 {
+		pinmux = <STM32_PINMUX('K', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp255fajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255fajx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp255fakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255fakx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp255falx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp255falx-pinctrl.dtsi
@@ -3554,6 +3554,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp257aaix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257aaix-pinctrl.dtsi
@@ -4260,6 +4260,273 @@
 		pinmux = <STM32_PINMUX('J', 15, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pi14: mdf1_sdi1_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pi15: mdf1_cki2_pi15 {
+		pinmux = <STM32_PINMUX('I', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pj4: mdf1_cck1_pj4 {
+		pinmux = <STM32_PINMUX('J', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pk0: mdf1_cck0_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pk1: mdf1_sdi2_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pk3: mdf1_cki1_pk3 {
+		pinmux = <STM32_PINMUX('K', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pk5: mdf1_cki0_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pk7: mdf1_sdi0_pk7 {
+		pinmux = <STM32_PINMUX('K', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp257aajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257aajx-pinctrl.dtsi
@@ -3664,6 +3664,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp257aakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257aakx-pinctrl.dtsi
@@ -3664,6 +3664,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp257aalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257aalx-pinctrl.dtsi
@@ -3664,6 +3664,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp257caix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257caix-pinctrl.dtsi
@@ -4260,6 +4260,273 @@
 		pinmux = <STM32_PINMUX('J', 15, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pi14: mdf1_sdi1_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pi15: mdf1_cki2_pi15 {
+		pinmux = <STM32_PINMUX('I', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pj4: mdf1_cck1_pj4 {
+		pinmux = <STM32_PINMUX('J', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pk0: mdf1_cck0_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pk1: mdf1_sdi2_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pk3: mdf1_cki1_pk3 {
+		pinmux = <STM32_PINMUX('K', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pk5: mdf1_cki0_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pk7: mdf1_sdi0_pk7 {
+		pinmux = <STM32_PINMUX('K', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp257cajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257cajx-pinctrl.dtsi
@@ -3664,6 +3664,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp257cakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257cakx-pinctrl.dtsi
@@ -3664,6 +3664,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp257calx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257calx-pinctrl.dtsi
@@ -3664,6 +3664,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp257daix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257daix-pinctrl.dtsi
@@ -4260,6 +4260,273 @@
 		pinmux = <STM32_PINMUX('J', 15, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pi14: mdf1_sdi1_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pi15: mdf1_cki2_pi15 {
+		pinmux = <STM32_PINMUX('I', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pj4: mdf1_cck1_pj4 {
+		pinmux = <STM32_PINMUX('J', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pk0: mdf1_cck0_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pk1: mdf1_sdi2_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pk3: mdf1_cki1_pk3 {
+		pinmux = <STM32_PINMUX('K', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pk5: mdf1_cki0_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pk7: mdf1_sdi0_pk7 {
+		pinmux = <STM32_PINMUX('K', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp257dajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257dajx-pinctrl.dtsi
@@ -3664,6 +3664,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp257dakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257dakx-pinctrl.dtsi
@@ -3664,6 +3664,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp257dalx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257dalx-pinctrl.dtsi
@@ -3664,6 +3664,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp257faix-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257faix-pinctrl.dtsi
@@ -4260,6 +4260,273 @@
 		pinmux = <STM32_PINMUX('J', 15, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pi14: mdf1_sdi1_pi14 {
+		pinmux = <STM32_PINMUX('I', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pi15: mdf1_cki2_pi15 {
+		pinmux = <STM32_PINMUX('I', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pj4: mdf1_cck1_pj4 {
+		pinmux = <STM32_PINMUX('J', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pk0: mdf1_cck0_pk0 {
+		pinmux = <STM32_PINMUX('K', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pk1: mdf1_sdi2_pk1 {
+		pinmux = <STM32_PINMUX('K', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pk3: mdf1_cki1_pk3 {
+		pinmux = <STM32_PINMUX('K', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pk5: mdf1_cki0_pk5 {
+		pinmux = <STM32_PINMUX('K', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pk7: mdf1_sdi0_pk7 {
+		pinmux = <STM32_PINMUX('K', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp257fajx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257fajx-pinctrl.dtsi
@@ -3664,6 +3664,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp257fakx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257fakx-pinctrl.dtsi
@@ -3664,6 +3664,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/mp2/stm32mp257falx-pinctrl.dtsi
+++ b/dts/st/mp2/stm32mp257falx-pinctrl.dtsi
@@ -3664,6 +3664,233 @@
 		pinmux = <STM32_PINMUX('I', 9, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi7_pa2: mdf1_sdi7_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pa3: mdf1_cki7_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pa6: mdf1_sdi6_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pa7: mdf1_cck0_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pa11: mdf1_sdi4_pa11 {
+		pinmux = <STM32_PINMUX('A', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pa13: mdf1_cki3_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pa14: mdf1_cck1_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pb2: mdf1_cki3_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pb3: mdf1_sdi3_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pb4: mdf1_sdi4_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pb5: mdf1_cki4_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pb14: mdf1_cki7_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc2: mdf1_sdi3_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc5: mdf1_sdi1_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc6: mdf1_cki1_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pc12: mdf1_cki2_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pd6: mdf1_sdi2_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pd7: mdf1_cki2_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd8: mdf1_sdi1_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd9: mdf1_cki1_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd10: mdf1_sdi0_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd11: mdf1_cki0_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pd13: mdf1_sdi7_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe8: mdf1_cki0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe12: mdf1_sdi0_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pe14: mdf1_cki6_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pe15: mdf1_sdi6_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pf1: mdf1_cki4_pf1 {
+		pinmux = <STM32_PINMUX('F', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pf9: mdf1_sdi5_pf9 {
+		pinmux = <STM32_PINMUX('F', 9, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pf10: mdf1_cki6_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pf11: mdf1_sdi6_pf11 {
+		pinmux = <STM32_PINMUX('F', 11, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki7_pf13: mdf1_cki7_pf13 {
+		pinmux = <STM32_PINMUX('F', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi7_pf14: mdf1_sdi7_pf14 {
+		pinmux = <STM32_PINMUX('F', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pg0: mdf1_sdi2_pg0 {
+		pinmux = <STM32_PINMUX('G', 0, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki6_pg13: mdf1_cki6_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pg14: mdf1_cki5_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pg15: mdf1_sdi5_pg15 {
+		pinmux = <STM32_PINMUX('G', 15, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi6_pi1: mdf1_sdi6_pi1 {
+		pinmux = <STM32_PINMUX('I', 1, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pi10: mdf1_cck0_pi10 {
+		pinmux = <STM32_PINMUX('I', 10, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz3: mdf1_sdi5_pz3 {
+		pinmux = <STM32_PINMUX('Z', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz4: mdf1_cck1_pz4 {
+		pinmux = <STM32_PINMUX('Z', 4, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pz7: mdf1_cck1_pz7 {
+		pinmux = <STM32_PINMUX('Z', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pz8: mdf1_sdi5_pz8 {
+		pinmux = <STM32_PINMUX('Z', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pz9: mdf1_cki5_pz9 {
+		pinmux = <STM32_PINMUX('Z', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_io0_pb0: octospim_p2_io0_pb0 {

--- a/dts/st/n6/stm32n645a0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645a0hxq-pinctrl.dtsi
@@ -2077,6 +2077,88 @@
 		pinmux = <STM32_PINMUX('N', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb3: mdf1_cki1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd2: mdf1_sdi1_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd10: mdf1_cki3_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pd12: mdf1_sdi3_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n645b0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645b0hxq-pinctrl.dtsi
@@ -2952,6 +2952,88 @@
 		pinmux = <STM32_PINMUX('O', 4, AF10)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb3: mdf1_cki1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd2: mdf1_sdi1_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd10: mdf1_cki3_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pd12: mdf1_sdi3_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n645i0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645i0hxq-pinctrl.dtsi
@@ -2634,6 +2634,93 @@
 		pinmux = <STM32_PINMUX('N', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb2: mdf1_sdi1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb3: mdf1_cki1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd2: mdf1_sdi1_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd10: mdf1_cki3_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pd12: mdf1_sdi3_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n645l0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645l0hxq-pinctrl.dtsi
@@ -3265,6 +3265,93 @@
 		pinmux = <STM32_PINMUX('P', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb2: mdf1_sdi1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb3: mdf1_cki1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd2: mdf1_sdi1_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd10: mdf1_cki3_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pd12: mdf1_sdi3_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n645x0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645x0hxq-pinctrl.dtsi
@@ -3554,6 +3554,103 @@
 		pinmux = <STM32_PINMUX('P', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb2: mdf1_sdi1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb3: mdf1_cki1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc2: mdf1_sdi1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd2: mdf1_sdi1_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd10: mdf1_cki3_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pd12: mdf1_sdi3_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n645z0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n645z0hxq-pinctrl.dtsi
@@ -1214,6 +1214,63 @@
 		pinmux = <STM32_PINMUX('N', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n647a0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647a0hxq-pinctrl.dtsi
@@ -2077,6 +2077,88 @@
 		pinmux = <STM32_PINMUX('N', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb3: mdf1_cki1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd2: mdf1_sdi1_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd10: mdf1_cki3_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pd12: mdf1_sdi3_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n647b0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647b0hxq-pinctrl.dtsi
@@ -2952,6 +2952,88 @@
 		pinmux = <STM32_PINMUX('O', 4, AF10)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb3: mdf1_cki1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd2: mdf1_sdi1_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd10: mdf1_cki3_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pd12: mdf1_sdi3_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n647i0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647i0hxq-pinctrl.dtsi
@@ -2634,6 +2634,93 @@
 		pinmux = <STM32_PINMUX('N', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb2: mdf1_sdi1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb3: mdf1_cki1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd2: mdf1_sdi1_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd10: mdf1_cki3_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pd12: mdf1_sdi3_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n647l0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647l0hxq-pinctrl.dtsi
@@ -3265,6 +3265,93 @@
 		pinmux = <STM32_PINMUX('P', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb2: mdf1_sdi1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb3: mdf1_cki1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd2: mdf1_sdi1_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd10: mdf1_cki3_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pd12: mdf1_sdi3_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n647x0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647x0hxq-pinctrl.dtsi
@@ -3554,6 +3554,103 @@
 		pinmux = <STM32_PINMUX('P', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb2: mdf1_sdi1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb3: mdf1_cki1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc2: mdf1_sdi1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd2: mdf1_sdi1_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd10: mdf1_cki3_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pd12: mdf1_sdi3_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n647z0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n647z0hxq-pinctrl.dtsi
@@ -1214,6 +1214,63 @@
 		pinmux = <STM32_PINMUX('N', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n655a0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655a0hxq-pinctrl.dtsi
@@ -2077,6 +2077,88 @@
 		pinmux = <STM32_PINMUX('N', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb3: mdf1_cki1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd2: mdf1_sdi1_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd10: mdf1_cki3_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pd12: mdf1_sdi3_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n655b0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655b0hxq-pinctrl.dtsi
@@ -2952,6 +2952,88 @@
 		pinmux = <STM32_PINMUX('O', 4, AF10)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb3: mdf1_cki1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd2: mdf1_sdi1_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd10: mdf1_cki3_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pd12: mdf1_sdi3_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n655i0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655i0hxq-pinctrl.dtsi
@@ -2634,6 +2634,93 @@
 		pinmux = <STM32_PINMUX('N', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb2: mdf1_sdi1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb3: mdf1_cki1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd2: mdf1_sdi1_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd10: mdf1_cki3_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pd12: mdf1_sdi3_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n655l0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655l0hxq-pinctrl.dtsi
@@ -3265,6 +3265,93 @@
 		pinmux = <STM32_PINMUX('P', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb2: mdf1_sdi1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb3: mdf1_cki1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd2: mdf1_sdi1_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd10: mdf1_cki3_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pd12: mdf1_sdi3_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n655x0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655x0hxq-pinctrl.dtsi
@@ -3554,6 +3554,103 @@
 		pinmux = <STM32_PINMUX('P', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb2: mdf1_sdi1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb3: mdf1_cki1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc2: mdf1_sdi1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd2: mdf1_sdi1_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd10: mdf1_cki3_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pd12: mdf1_sdi3_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n655z0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n655z0hxq-pinctrl.dtsi
@@ -1214,6 +1214,63 @@
 		pinmux = <STM32_PINMUX('N', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n657a0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657a0hxq-pinctrl.dtsi
@@ -2077,6 +2077,88 @@
 		pinmux = <STM32_PINMUX('N', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb3: mdf1_cki1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd2: mdf1_sdi1_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd10: mdf1_cki3_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pd12: mdf1_sdi3_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n657b0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657b0hxq-pinctrl.dtsi
@@ -2952,6 +2952,88 @@
 		pinmux = <STM32_PINMUX('O', 4, AF10)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb3: mdf1_cki1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd2: mdf1_sdi1_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd10: mdf1_cki3_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pd12: mdf1_sdi3_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n657i0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657i0hxq-pinctrl.dtsi
@@ -2634,6 +2634,93 @@
 		pinmux = <STM32_PINMUX('N', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb2: mdf1_sdi1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb3: mdf1_cki1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd2: mdf1_sdi1_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd10: mdf1_cki3_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pd12: mdf1_sdi3_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n657l0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657l0hxq-pinctrl.dtsi
@@ -3265,6 +3265,93 @@
 		pinmux = <STM32_PINMUX('P', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb2: mdf1_sdi1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb3: mdf1_cki1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd2: mdf1_sdi1_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd10: mdf1_cki3_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pd12: mdf1_sdi3_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n657x0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657x0hxq-pinctrl.dtsi
@@ -3554,6 +3554,103 @@
 		pinmux = <STM32_PINMUX('P', 15, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb2: mdf1_sdi1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb3: mdf1_cki1_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pc0: mdf1_cki1_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pc2: mdf1_sdi1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd2: mdf1_sdi1_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pd10: mdf1_cki3_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pd12: mdf1_sdi3_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe11: mdf1_cki5_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/n6/stm32n657z0hxq-pinctrl.dtsi
+++ b/dts/st/n6/stm32n657z0hxq-pinctrl.dtsi
@@ -1214,6 +1214,63 @@
 		pinmux = <STM32_PINMUX('N', 11, AF14)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi2_pb0: mdf1_sdi2_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pb6: mdf1_cck1_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb7: mdf1_sdi1_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe2: mdf1_cck0_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe3: mdf1_cki2_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pe7: mdf1_cki0_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pe8: mdf1_sdi0_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe9: mdf1_cki4_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pf10: mdf1_sdi3_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF4)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_1_pa8: rcc_mco_1_pa8 {

--- a/dts/st/u5/stm32u535cbtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cbtx-pinctrl.dtsi
@@ -516,6 +516,33 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535cbtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cbtxq-pinctrl.dtsi
@@ -448,6 +448,23 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535cbux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cbux-pinctrl.dtsi
@@ -516,6 +516,33 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535cbuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cbuxq-pinctrl.dtsi
@@ -448,6 +448,23 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535cctx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cctx-pinctrl.dtsi
@@ -516,6 +516,33 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535cctxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cctxq-pinctrl.dtsi
@@ -448,6 +448,23 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535ccux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535ccux-pinctrl.dtsi
@@ -516,6 +516,33 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535ccuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535ccuxq-pinctrl.dtsi
@@ -448,6 +448,23 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535cetx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cetx-pinctrl.dtsi
@@ -516,6 +516,33 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535cetxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535cetxq-pinctrl.dtsi
@@ -448,6 +448,23 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535ceux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535ceux-pinctrl.dtsi
@@ -516,6 +516,33 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535ceuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535ceuxq-pinctrl.dtsi
@@ -448,6 +448,23 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535jeyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535jeyxq-pinctrl.dtsi
@@ -629,6 +629,33 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535ncyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535ncyxq-pinctrl.dtsi
@@ -516,6 +516,33 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535neyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535neyxq-pinctrl.dtsi
@@ -516,6 +516,33 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535rbix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rbix-pinctrl.dtsi
@@ -712,6 +712,38 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535rbixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rbixq-pinctrl.dtsi
@@ -657,6 +657,33 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535rbtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rbtx-pinctrl.dtsi
@@ -712,6 +712,38 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535rbtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rbtxq-pinctrl.dtsi
@@ -657,6 +657,33 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535rcix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rcix-pinctrl.dtsi
@@ -712,6 +712,38 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535rcixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rcixq-pinctrl.dtsi
@@ -657,6 +657,33 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535rctx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rctx-pinctrl.dtsi
@@ -712,6 +712,38 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535rctxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535rctxq-pinctrl.dtsi
@@ -657,6 +657,33 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535reix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535reix-pinctrl.dtsi
@@ -712,6 +712,38 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535reixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535reixq-pinctrl.dtsi
@@ -657,6 +657,33 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535retx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535retx-pinctrl.dtsi
@@ -712,6 +712,38 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535retxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535retxq-pinctrl.dtsi
@@ -657,6 +657,33 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535vcix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vcix-pinctrl.dtsi
@@ -1079,6 +1079,63 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535vcixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vcixq-pinctrl.dtsi
@@ -1045,6 +1045,58 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535vctx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vctx-pinctrl.dtsi
@@ -1079,6 +1079,63 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535vctxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vctxq-pinctrl.dtsi
@@ -1045,6 +1045,58 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535veix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535veix-pinctrl.dtsi
@@ -1079,6 +1079,63 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535veixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535veixq-pinctrl.dtsi
@@ -1045,6 +1045,58 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535vetx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vetx-pinctrl.dtsi
@@ -1079,6 +1079,63 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u535vetxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u535vetxq-pinctrl.dtsi
@@ -1045,6 +1045,58 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u545cetx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545cetx-pinctrl.dtsi
@@ -516,6 +516,33 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u545cetxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545cetxq-pinctrl.dtsi
@@ -448,6 +448,23 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u545ceux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545ceux-pinctrl.dtsi
@@ -516,6 +516,33 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u545ceuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545ceuxq-pinctrl.dtsi
@@ -448,6 +448,23 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u545jeyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545jeyxq-pinctrl.dtsi
@@ -629,6 +629,33 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u545neyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545neyxq-pinctrl.dtsi
@@ -516,6 +516,33 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u545reix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545reix-pinctrl.dtsi
@@ -712,6 +712,38 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u545reixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545reixq-pinctrl.dtsi
@@ -657,6 +657,33 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u545retx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545retx-pinctrl.dtsi
@@ -712,6 +712,38 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u545retxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545retxq-pinctrl.dtsi
@@ -657,6 +657,33 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u545veix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545veix-pinctrl.dtsi
@@ -1079,6 +1079,63 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u545veixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545veixq-pinctrl.dtsi
@@ -1045,6 +1045,58 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u545vetx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545vetx-pinctrl.dtsi
@@ -1079,6 +1079,63 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u545vetxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u545vetxq-pinctrl.dtsi
@@ -1045,6 +1045,58 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospi1_ncs_pa0: octospi1_ncs_pa0 {

--- a/dts/st/u5/stm32u575agix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575agix-pinctrl.dtsi
@@ -1967,6 +1967,153 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575agixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575agixq-pinctrl.dtsi
@@ -1923,6 +1923,153 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575aiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575aiix-pinctrl.dtsi
@@ -1967,6 +1967,153 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575aiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575aiixq-pinctrl.dtsi
@@ -1923,6 +1923,153 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575cgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cgtx-pinctrl.dtsi
@@ -524,6 +524,53 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575cgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cgtxq-pinctrl.dtsi
@@ -456,6 +456,43 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575cgux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cgux-pinctrl.dtsi
@@ -524,6 +524,53 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575cguxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cguxq-pinctrl.dtsi
@@ -456,6 +456,43 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575citx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575citx-pinctrl.dtsi
@@ -524,6 +524,53 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575citxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575citxq-pinctrl.dtsi
@@ -456,6 +456,43 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575ciux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ciux-pinctrl.dtsi
@@ -524,6 +524,53 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575ciuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ciuxq-pinctrl.dtsi
@@ -456,6 +456,43 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575ogyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ogyxq-pinctrl.dtsi
@@ -1081,6 +1081,108 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575oiyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575oiyxq-pinctrl.dtsi
@@ -1081,6 +1081,108 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575qgix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qgix-pinctrl.dtsi
@@ -1713,6 +1713,148 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575qgixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qgixq-pinctrl.dtsi
@@ -1651,6 +1651,148 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575qiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qiix-pinctrl.dtsi
@@ -1713,6 +1713,148 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575qiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qiixq-pinctrl.dtsi
@@ -1651,6 +1651,148 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575rgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575rgtx-pinctrl.dtsi
@@ -817,6 +817,78 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575rgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575rgtxq-pinctrl.dtsi
@@ -665,6 +665,73 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575ritx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ritx-pinctrl.dtsi
@@ -817,6 +817,78 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575ritxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ritxq-pinctrl.dtsi
@@ -665,6 +665,73 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575vgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vgtx-pinctrl.dtsi
@@ -1305,6 +1305,143 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575vgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vgtxq-pinctrl.dtsi
@@ -1269,6 +1269,138 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vitx-pinctrl.dtsi
@@ -1305,6 +1305,143 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vitxq-pinctrl.dtsi
@@ -1269,6 +1269,138 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575zgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zgtx-pinctrl.dtsi
@@ -1731,6 +1731,153 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575zgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zgtxq-pinctrl.dtsi
@@ -1702,6 +1702,148 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575zitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zitx-pinctrl.dtsi
@@ -1731,6 +1731,153 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u575zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zitxq-pinctrl.dtsi
@@ -1702,6 +1702,148 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u585aiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585aiix-pinctrl.dtsi
@@ -1967,6 +1967,153 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u585aiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585aiixq-pinctrl.dtsi
@@ -1923,6 +1923,153 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u585citx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585citx-pinctrl.dtsi
@@ -524,6 +524,53 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u585citxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585citxq-pinctrl.dtsi
@@ -456,6 +456,43 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u585ciux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ciux-pinctrl.dtsi
@@ -524,6 +524,53 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u585ciuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ciuxq-pinctrl.dtsi
@@ -456,6 +456,43 @@
 		pinmux = <STM32_PINMUX('B', 14, AF2)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u585oiyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585oiyxq-pinctrl.dtsi
@@ -1081,6 +1081,108 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u585qiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585qiix-pinctrl.dtsi
@@ -1713,6 +1713,148 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u585qiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585qiixq-pinctrl.dtsi
@@ -1651,6 +1651,148 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u585ritx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ritx-pinctrl.dtsi
@@ -817,6 +817,78 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u585ritxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ritxq-pinctrl.dtsi
@@ -665,6 +665,73 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u585vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585vitx-pinctrl.dtsi
@@ -1305,6 +1305,143 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u585vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585vitxq-pinctrl.dtsi
@@ -1269,6 +1269,138 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u585zitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585zitx-pinctrl.dtsi
@@ -1731,6 +1731,153 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u585zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585zitxq-pinctrl.dtsi
@@ -1702,6 +1702,148 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595aihx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595aihx-pinctrl.dtsi
@@ -2113,6 +2113,168 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595aihxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595aihxq-pinctrl.dtsi
@@ -2069,6 +2069,168 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595ajhx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595ajhx-pinctrl.dtsi
@@ -2113,6 +2113,168 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595ajhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595ajhxq-pinctrl.dtsi
@@ -2069,6 +2069,168 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595qiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595qiix-pinctrl.dtsi
@@ -1842,6 +1842,163 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595qiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595qiixq-pinctrl.dtsi
@@ -1780,6 +1780,163 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595qjix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595qjix-pinctrl.dtsi
@@ -1842,6 +1842,163 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595qjixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595qjixq-pinctrl.dtsi
@@ -1780,6 +1780,163 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595ritx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595ritx-pinctrl.dtsi
@@ -885,6 +885,78 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595ritxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595ritxq-pinctrl.dtsi
@@ -725,6 +725,73 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595rjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595rjtx-pinctrl.dtsi
@@ -885,6 +885,78 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595rjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595rjtxq-pinctrl.dtsi
@@ -725,6 +725,73 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595vitx-pinctrl.dtsi
@@ -1422,6 +1422,143 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595vitxq-pinctrl.dtsi
@@ -1368,6 +1368,138 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595vjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595vjtx-pinctrl.dtsi
@@ -1422,6 +1422,143 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595vjtxq-pinctrl.dtsi
@@ -1368,6 +1368,138 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595zitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595zitx-pinctrl.dtsi
@@ -1860,6 +1860,168 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595zitxq-pinctrl.dtsi
@@ -1813,6 +1813,163 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595ziyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595ziyxq-pinctrl.dtsi
@@ -1880,6 +1880,168 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595zjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595zjtx-pinctrl.dtsi
@@ -1860,6 +1860,168 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595zjtxq-pinctrl.dtsi
@@ -1813,6 +1813,163 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u595zjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595zjyxq-pinctrl.dtsi
@@ -1880,6 +1880,168 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u599bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599bjyxq-pinctrl.dtsi
@@ -2423,6 +2423,168 @@
 		pinmux = <STM32_PINMUX('G', 14, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u599nihxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599nihxq-pinctrl.dtsi
@@ -2496,6 +2496,168 @@
 		pinmux = <STM32_PINMUX('G', 14, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u599njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599njhxq-pinctrl.dtsi
@@ -2496,6 +2496,168 @@
 		pinmux = <STM32_PINMUX('G', 14, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u599vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599vitxq-pinctrl.dtsi
@@ -1494,6 +1494,138 @@
 		pinmux = <STM32_PINMUX('E', 15, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u599vjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599vjtx-pinctrl.dtsi
@@ -1552,6 +1552,143 @@
 		pinmux = <STM32_PINMUX('E', 15, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u599vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599vjtxq-pinctrl.dtsi
@@ -1494,6 +1494,138 @@
 		pinmux = <STM32_PINMUX('E', 15, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u599zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599zitxq-pinctrl.dtsi
@@ -1975,6 +1975,163 @@
 		pinmux = <STM32_PINMUX('G', 14, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u599ziyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599ziyxq-pinctrl.dtsi
@@ -1928,6 +1928,168 @@
 		pinmux = <STM32_PINMUX('G', 6, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u599zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599zjtxq-pinctrl.dtsi
@@ -1975,6 +1975,163 @@
 		pinmux = <STM32_PINMUX('G', 14, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u599zjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599zjyxq-pinctrl.dtsi
@@ -1928,6 +1928,168 @@
 		pinmux = <STM32_PINMUX('G', 6, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5a5ajhx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5ajhx-pinctrl.dtsi
@@ -2113,6 +2113,168 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5a5ajhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5ajhxq-pinctrl.dtsi
@@ -2069,6 +2069,168 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5a5qiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5qiixq-pinctrl.dtsi
@@ -1780,6 +1780,163 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5a5qjix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5qjix-pinctrl.dtsi
@@ -1842,6 +1842,163 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5a5qjixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5qjixq-pinctrl.dtsi
@@ -1780,6 +1780,163 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5a5rjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5rjtx-pinctrl.dtsi
@@ -885,6 +885,78 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5a5rjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5rjtxq-pinctrl.dtsi
@@ -725,6 +725,73 @@
 		pinmux = <STM32_PINMUX('D', 2, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5a5vjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5vjtx-pinctrl.dtsi
@@ -1422,6 +1422,143 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5a5vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5vjtxq-pinctrl.dtsi
@@ -1368,6 +1368,138 @@
 		pinmux = <STM32_PINMUX('D', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5a5zjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5zjtx-pinctrl.dtsi
@@ -1860,6 +1860,168 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5a5zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5zjtxq-pinctrl.dtsi
@@ -1813,6 +1813,163 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5a5zjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5zjyxq-pinctrl.dtsi
@@ -1880,6 +1880,168 @@
 		pinmux = <STM32_PINMUX('F', 13, AF13)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5a9bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9bjyxq-pinctrl.dtsi
@@ -2423,6 +2423,168 @@
 		pinmux = <STM32_PINMUX('G', 14, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5a9njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9njhxq-pinctrl.dtsi
@@ -2496,6 +2496,168 @@
 		pinmux = <STM32_PINMUX('G', 14, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5a9vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9vjtxq-pinctrl.dtsi
@@ -1494,6 +1494,138 @@
 		pinmux = <STM32_PINMUX('E', 15, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5a9zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9zjtxq-pinctrl.dtsi
@@ -1975,6 +1975,163 @@
 		pinmux = <STM32_PINMUX('G', 14, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5a9zjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9zjyxq-pinctrl.dtsi
@@ -1928,6 +1928,168 @@
 		pinmux = <STM32_PINMUX('G', 6, AF7)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5f7vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f7vitx-pinctrl.dtsi
@@ -1542,6 +1542,143 @@
 		pinmux = <STM32_PINMUX('E', 15, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5f7vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f7vitxq-pinctrl.dtsi
@@ -1484,6 +1484,138 @@
 		pinmux = <STM32_PINMUX('E', 15, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5f7vjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f7vjtx-pinctrl.dtsi
@@ -1542,6 +1542,143 @@
 		pinmux = <STM32_PINMUX('E', 15, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5f7vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f7vjtxq-pinctrl.dtsi
@@ -1484,6 +1484,138 @@
 		pinmux = <STM32_PINMUX('E', 15, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5f9bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9bjyxq-pinctrl.dtsi
@@ -2397,6 +2397,168 @@
 		pinmux = <STM32_PINMUX('G', 14, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5f9njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9njhxq-pinctrl.dtsi
@@ -2470,6 +2470,168 @@
 		pinmux = <STM32_PINMUX('G', 14, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5f9vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9vitxq-pinctrl.dtsi
@@ -1087,6 +1087,93 @@
 		pinmux = <STM32_PINMUX('E', 10, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5f9vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9vjtxq-pinctrl.dtsi
@@ -1087,6 +1087,93 @@
 		pinmux = <STM32_PINMUX('E', 10, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5f9zijxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zijxq-pinctrl.dtsi
@@ -1837,6 +1837,138 @@
 		pinmux = <STM32_PINMUX('G', 14, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5f9zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zitxq-pinctrl.dtsi
@@ -1837,6 +1837,138 @@
 		pinmux = <STM32_PINMUX('G', 14, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5f9zjjxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zjjxq-pinctrl.dtsi
@@ -1837,6 +1837,138 @@
 		pinmux = <STM32_PINMUX('G', 14, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5f9zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5f9zjtxq-pinctrl.dtsi
@@ -1837,6 +1837,138 @@
 		pinmux = <STM32_PINMUX('G', 14, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5g7vjtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g7vjtx-pinctrl.dtsi
@@ -1570,6 +1570,143 @@
 		pinmux = <STM32_PINMUX('E', 15, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5g7vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g7vjtxq-pinctrl.dtsi
@@ -1512,6 +1512,138 @@
 		pinmux = <STM32_PINMUX('E', 15, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5g9bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9bjyxq-pinctrl.dtsi
@@ -2397,6 +2397,168 @@
 		pinmux = <STM32_PINMUX('G', 14, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5g9njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9njhxq-pinctrl.dtsi
@@ -2514,6 +2514,168 @@
 		pinmux = <STM32_PINMUX('G', 14, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pb12: mdf1_sdi1_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pf3: mdf1_cck0_pf3 {
+		pinmux = <STM32_PINMUX('F', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pf4: mdf1_sdi0_pf4 {
+		pinmux = <STM32_PINMUX('F', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pf5: mdf1_cki0_pf5 {
+		pinmux = <STM32_PINMUX('F', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pf10: mdf1_cck1_pf10 {
+		pinmux = <STM32_PINMUX('F', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pg7: mdf1_cck0_pg7 {
+		pinmux = <STM32_PINMUX('G', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5g9vjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9vjtxq-pinctrl.dtsi
@@ -1123,6 +1123,93 @@
 		pinmux = <STM32_PINMUX('E', 10, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5g9zjjxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9zjjxq-pinctrl.dtsi
@@ -1873,6 +1873,138 @@
 		pinmux = <STM32_PINMUX('G', 14, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/dts/st/u5/stm32u5g9zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5g9zjtxq-pinctrl.dtsi
@@ -1873,6 +1873,138 @@
 		pinmux = <STM32_PINMUX('G', 14, AF8)>;
 	};
 
+	/* MDF */
+
+	/omit-if-no-ref/ mdf1_sdi0_pb1: mdf1_sdi0_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pb2: mdf1_cki0_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pb6: mdf1_sdi5_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pb7: mdf1_cki5_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pb8: mdf1_cck0_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF5)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pb13: mdf1_cki1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pb14: mdf1_sdi2_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pb15: mdf1_cki2_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pc0: mdf1_sdi4_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pc1: mdf1_cki4_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck1_pc2: mdf1_cck1_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pc6: mdf1_cki3_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pc7: mdf1_sdi3_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi0_pd3: mdf1_sdi0_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki0_pd4: mdf1_cki0_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi1_pd6: mdf1_sdi1_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki1_pd7: mdf1_cki1_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi3_pe4: mdf1_sdi3_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki3_pe5: mdf1_cki3_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi2_pe7: mdf1_sdi2_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki2_pe8: mdf1_cki2_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cck0_pe9: mdf1_cck0_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi4_pe10: mdf1_sdi4_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki4_pe11: mdf1_cki4_pe11 {
+		pinmux = <STM32_PINMUX('E', 11, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_sdi5_pe12: mdf1_sdi5_pe12 {
+		pinmux = <STM32_PINMUX('E', 12, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
+	/omit-if-no-ref/ mdf1_cki5_pe13: mdf1_cki5_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF6)>;
+		slew-rate = "very-high-speed";
+	};
+
 	/* OCTOSPI */
 
 	/omit-if-no-ref/ octospim_p2_ncs_pa0: octospim_p2_ncs_pa0 {

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -176,6 +176,10 @@
 - name: LTDC
   match: "^LTDC_(?:DE|CLK|HSYNC|VSYNC|R[0-7]|G[0-7]|B[0-7])$"
 
+- name: MDF
+  match: "^MDF1_(?:CCK[0-1]|CKI[0-7]|SDI[0-7])$"
+  slew-rate: very-high-speed
+
 - name: OCTOSPI
   match: "^OCTOSPI(.*)(?:CLK|NCS[1-2]?|DQS|IO[0-7])$"
   slew-rate: very-high-speed


### PR DESCRIPTION
As title says, this PR aims to add MDF pinctrl support.
MDF is available on MP2, N6, U3 and U5.

This PR depends on #367

Edit: #367 has been merged.