### PR TITLE
scripts: genpinctrl: only wipe folder of series we generate pinctrl for 

### DIFF
--- a/scripts/genpinctrl/genpinctrl.py
+++ b/scripts/genpinctrl/genpinctrl.py
@@ -17,7 +17,7 @@ import logging
 from pathlib import Path
 import re
 import shutil
-from subprocess import check_output, STDOUT, CalledProcessError, run
+from subprocess import check_output, STDOUT, CalledProcessError
 import xml.etree.ElementTree as ET
 
 from jinja2 import Environment, FileSystemLoader
@@ -78,11 +78,6 @@ SUPPORTED_FAMILIES = [
     "stm32wl",
 ]
 """Supported SoC families"""
-
-HAL2_FAMILIES = [
-    "stm32c5",
-]
-"""SoC families relying on HAL2"""
 
 PIN_MODS = [
     "_C",  # Pins with analog switch (H7)
@@ -628,18 +623,6 @@ def main(data_path, output):
     gpio_ip_afs = get_gpio_ip_afs(data_path)
     mcu_signals = get_mcu_signals(data_path, gpio_ip_afs)
 
-    # erase output if we're about to generate for all families
-    if output.exists() and not FAMILY_FILTER.is_active():
-        shutil.rmtree(output)
-        output.mkdir(parents=True)
-        # Do not consider SoCs related to HAL2
-        for family in HAL2_FAMILIES:
-            family_path = output / "st" / family.removeprefix("stm32")
-            try:
-                run(["git", "checkout", "--", family_path], check=True)
-            except CalledProcessError:
-                break
-
     for family, refs in mcu_signals.items():
         # check family is supported
         if family.lower() not in SUPPORTED_FAMILIES:
@@ -648,8 +631,13 @@ def main(data_path, output):
         else:
             logger.info(f"Processing family {family}...")
 
-        # create destination directory for the family
+        # Create destination directory for the family,
+        # but wipe it first if we're generating for all
+        # families (i.e., family filter is not active).
         family_dir = output / "st" / family.lower().removeprefix("stm32")
+
+        if family_dir.exists() and not FAMILY_FILTER.is_active():
+            shutil.rmtree(family_dir)
         family_dir.mkdir(parents=True, exist_ok=True)
 
         # process each reference of the family

--- a/scripts/genpinctrl/genpinctrl.py
+++ b/scripts/genpinctrl/genpinctrl.py
@@ -66,6 +66,7 @@ SUPPORTED_FAMILIES = [
     "stm32l4",
     "stm32l5",
     "stm32mp1",
+    "stm32mp13",
     "stm32mp2",
     "stm32n6",
     "stm32u0",
@@ -456,6 +457,16 @@ def get_mcu_signals(data_path, gpio_ip_afs):
         family = mcu_root.get("Family").replace("+", "")
         ref = mcu_root.get("RefName")
 
+        # STM32MP13 line and STM32MP15 line SoCs are grouped under
+        # the same "STM32MP1" family in Open Pin Data, but we want
+        # to generate pinctrl for these lines in separate directories.
+        # Change family based on SoC model if this is an MP1 SoC.
+        if family == "STM32MP1":
+            if ref.lower().startswith("stm32mp13"):
+                family = "STM32MP13"
+            elif ref.lower().startswith("stm32mp15"):
+                family = "STM32MP1"
+
         gpio_ip_version = None
         for ip in mcu_root.findall(NS + "IP"):
             if ip.get("Name") == "GPIO":
@@ -637,15 +648,12 @@ def main(data_path, output):
         else:
             logger.info(f"Processing family {family}...")
 
-        # create directory for each family and process each reference
-        for ref in refs:
-            if ref["name"].lower().startswith("stm32mp13"):
-                family_dir = output / "st" / "mp13"
-            else:
-                family_dir = output / "st" / family.lower()[5:]
-            if not family_dir.exists():
-                family_dir.mkdir(parents=True)
+        # create destination directory for the family
+        family_dir = output / "st" / family.lower().removeprefix("stm32")
+        family_dir.mkdir(parents=True, exist_ok=True)
 
+        # process each reference of the family
+        for ref in refs:
             entries = dict()
 
             # process each pin in the current reference


### PR DESCRIPTION
When generating pinctrl for all families, don't delete the entire output folder as it may contain pinctrl for STM32Cube HAL2 series which CANNOT be regenerated by the script. Instead, wipe the folder of every series for which we will generate pinctrl right before doing said generation. When a family filter is active, continue to delete nothing as is the
case today.

The first commit is some pre-requisite cleanup to avoid adding a huge MP1-specific quirk in the middle of the processing loop.
