### PR TITLE
lib: blobs: update stm32wba LL libraries to fix missing calibration functions

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -47,11 +47,11 @@ blobs:
     url: https://github.com/STMicroelectronics/STM32CubeWB0/raw/v1.4.0/Middlewares/ST/STM32_BLE/stack/lib/stm32wb0x_ble_stack_controller_only.a
     description: "Binary Stack library for the STM32WB0 Bluetooth subsystem"
   - path: stm32wba/lib/WBA6_LinkLayer15_4_Zephyr.a
-    sha256: cb3ec6c3cd921e927f0847ebf4efbe4dafd7e3ac4ee5c0bbe98e3368382f412c
+    sha256: 9c57260975aeb493b2914bbcb149b59b8c0c647881b3d12d0544fd78ba314bae
     type: lib
     version: '1.9.0'
     license-path: zephyr/blobs/stm32wba/lib/license.md
-    url: https://github.com/stm32-hotspot/STM32WBA-Zephyr-custom-binaries/raw/7343a38195df8a8fd4d31362a5d1568245d13c96/lib/WBA6_LinkLayer15_4_Zephyr.a
+    url: https://github.com/stm32-hotspot/STM32WBA-Zephyr-custom-binaries/raw/b31a6222a1a6b4f1a93012ee15968057df2f8fee/lib/WBA6_LinkLayer15_4_Zephyr.a
     description: "Binary Link Layer library for the STM32WBA6 802.15.4 subsystem"
   - path: stm32wba/lib/WBA6_LinkLayer_BLE_Basic_15_4_lib_Zephyr.a
     sha256: f7d217d7da11b7bdc1c3f290983048688062009063c195e41344969f079105f3
@@ -61,11 +61,11 @@ blobs:
     url: https://github.com/stm32-hotspot/STM32WBA-Zephyr-custom-binaries/raw/7343a38195df8a8fd4d31362a5d1568245d13c96/lib/WBA6_LinkLayer_BLE_Basic_15_4_lib_Zephyr.a
     description: "Binary Link Layer library including BLE Basic features for the STM32WBA6 BLE-802.15.4 Concurrent mode subsystem"
   - path: stm32wba/lib/WBA5_LinkLayer15_4_Zephyr.a
-    sha256: 43dfa7347297b013af1e37501a2d27c239df82537161333bb80b97ec83ac4804
+    sha256: b27fa4b3d43168efb7d4f2e7981eb8c7b590bbc27a05fe60e2137d82df80c617
     type: lib
     version: '1.9.0'
     license-path: zephyr/blobs/stm32wba/lib/license.md
-    url: https://github.com/stm32-hotspot/STM32WBA-Zephyr-custom-binaries/raw/7343a38195df8a8fd4d31362a5d1568245d13c96/lib/WBA5_LinkLayer15_4_Zephyr.a
+    url: https://github.com/stm32-hotspot/STM32WBA-Zephyr-custom-binaries/raw/b31a6222a1a6b4f1a93012ee15968057df2f8fee/lib/WBA5_LinkLayer15_4_Zephyr.a
     description: "Binary Link Layer library for the STM32WBA5 802.15.4 subsystem"
   - path: stm32wba/lib/WBA5_LinkLayer_BLE_Basic_15_4_lib_Zephyr.a
     sha256: 1f7eafad212e1b58a73b625822f94482f8202a8557e21c30bfc7eb24aabc1b68


### PR DESCRIPTION
This PR includes an update of the Link Layer libraries WBA5_LinkLayer15_4_Zephyr.a and WBA6_LinkLayer15_4_Zephyr.a to fix compilation issue due to missing calibration functions for 802154 only.

FYI : @asm5878 , @erwango , @etienne-lms 