### PR TITLE
stm32cube: stm32h5: fix ETH RX timestamp context handling

### DIFF
--- a/stm32cube/stm32h5xx/README
+++ b/stm32cube/stm32h5xx/README
@@ -57,6 +57,15 @@ Patch List:
      If the CTXT bit is set in the context descriptor then extract the timestamps
      ST internal bug : 161504
 
+   *Fix Ethernet RX timestamp context handling
+     Prevents stale or incomplete RX timestamps by clearing the cached timestamp,
+     reading only CPU-owned timestamp context descriptors, and advancing the RX
+     descriptor index after consuming a valid context descriptor. Packets with
+     timestamp context descriptors still owned by DMA are retried later.
+     Impacted file:
+      stm32cube/stm32h5xx/drivers/src/stm32h5xx_hal_eth.c
+     ST Internal Reference: 683183939fd90b986d0d8626d624ab85
+
    *Fix to remove PAGESIZE definition which conflicts with POSIX
     Impacted files:
      drivers/include/Legacy/stm32_hal_legacy.h

--- a/stm32cube/stm32h5xx/drivers/src/stm32h5xx_hal_eth.c
+++ b/stm32cube/stm32h5xx/drivers/src/stm32h5xx_hal_eth.c
@@ -1087,6 +1087,10 @@ HAL_StatusTypeDef HAL_ETH_ReadData(ETH_HandleTypeDef *heth, void **pAppBuff)
   dmarxdesc = (ETH_DMADescTypeDef *)heth->RxDescList.RxDesc[descidx];
   desccntmax = ETH_RX_DESC_CNT - heth->RxDescList.RxBuildDescCnt;
 
+  /* Initialize timestamp to an invalid value before checking received descriptors */
+  heth->RxDescList.TimeStamp.TimeStampHigh = UINT32_MAX;
+  heth->RxDescList.TimeStamp.TimeStampLow  = UINT32_MAX;
+
   /* Check if descriptor is not owned by DMA */
   while ((READ_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCWBF_OWN) == (uint32_t)RESET) && (desccnt < desccntmax)
          && (rxdataready == 0U))
@@ -1110,9 +1114,6 @@ HAL_StatusTypeDef HAL_ETH_ReadData(ETH_HandleTypeDef *heth, void **pAppBuff)
         /* Save Last descriptor index */
         heth->RxDescList.pRxLastRxDesc = dmarxdesc->DESC3;
 
-        /* Packet ready */
-        rxdataready = 1;
-
         if (READ_BIT(dmarxdesc->DESC1, ETH_DMARXNDESCWBF_TSA) != (uint32_t)RESET)
         {
           descidx_next = descidx;
@@ -1120,14 +1121,29 @@ HAL_StatusTypeDef HAL_ETH_ReadData(ETH_HandleTypeDef *heth, void **pAppBuff)
 
           dmarxdesc_next = (ETH_DMADescTypeDef *)heth->RxDescList.RxDesc[descidx_next];
 
-          if (READ_BIT(dmarxdesc_next->DESC3, ETH_DMARXNDESCWBF_CTXT) != (uint32_t)RESET)
+          if (READ_BIT(dmarxdesc_next->DESC3, ETH_DMARXNDESCWBF_OWN) == (uint32_t)RESET)
           {
-            /* Get timestamp high */
-            heth->RxDescList.TimeStamp.TimeStampHigh = dmarxdesc_next->DESC1;
-            /* Get timestamp low */
-            heth->RxDescList.TimeStamp.TimeStampLow  = dmarxdesc_next->DESC0;
+            if (READ_BIT(dmarxdesc_next->DESC3, ETH_DMARXNDESCWBF_CTXT) != (uint32_t)RESET)
+            {
+              /* Get timestamp high */
+              heth->RxDescList.TimeStamp.TimeStampHigh = dmarxdesc_next->DESC1;
+              /* Get timestamp low */
+              heth->RxDescList.TimeStamp.TimeStampLow  = dmarxdesc_next->DESC0;
+
+              /* Increment current rx descriptor index */
+              INCR_RX_DESC_INDEX(descidx, 1U);
+              desccnt++;
+            }
+          }
+          else
+          {
+            /* timestamp context descriptor is not ready, exit and retry later */
+            break;
           }
         }
+
+        /* Packet ready */
+        rxdataready = 1;
       }
 
       /* Link data */


### PR DESCRIPTION
This PR is part of a series of PTP-related PRs:
- https://github.com/zephyrproject-rtos/zephyr/pull/110580
- https://github.com/zephyrproject-rtos/zephyr/pull/110582

Equivalent PR:
- https://github.com/STMicroelectronics/stm32h5xx-hal-driver/pull/34

## Summary

Fix STM32H5 Ethernet RX timestamp context handling.

`HAL_ETH_ReadData()` could report stale or incomplete RX timestamps when PTP hardware timestamping was enabled. This happened because the HAL cached the last RX timestamp and read the descriptor after a timestamped packet without first checking whether that descriptor was already CPU-owned and marked as a context descriptor.

## Problem

With PTP traffic, STM32 Ethernet can place the RX hardware timestamp in a context descriptor following the received packet descriptor.

The previous code checked the following descriptor for `CTXT`, but did not check whether DMA still owned it. If the context descriptor was not ready yet, the HAL could read incomplete descriptor contents. If no fresh timestamp was produced,
the cached `RxDescList.TimeStamp` value could also make the caller see an old timestamp as if it belonged to the current packet.

Downstream, this showed up as occasional bad PTP RX timestamps, which caused large Sync/Pdelay time jumps and unstable clock correction.

## Solution

Clear the cached RX timestamp before reading a packet.

Only consume the following descriptor as an RX timestamp context descriptor when:
- DMA no longer owns the descriptor
- the descriptor is marked as a context descriptor

When a valid timestamp context descriptor is consumed, advance the RX descriptor index past it so the RX ring stays aligned.

## Testing

Tested downstream with Zephyr STM32H5 PTP traffic. The previous intermittent PTP timestamp warnings no longer reproduced during the follow-up long run.