### PR TITLE
stm32cube: mp2: revert erroneous changes to CMakeLists

### DIFF
--- a/stm32cube/stm32mp2xx/CMakeLists.txt
+++ b/stm32cube/stm32mp2xx/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Copyright (C) 2025 Savoir-faire Linux, Inc.
-# Copyright (c) 2020 STMicroelectronics
+# Copyright (c) 2025 STMicroelectronics
 #
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library_sources(soc/system_stm32mp2xx.c)
+zephyr_library_sources(soc/system_stm32mp2xx_m33.c)
 zephyr_library_sources(drivers/src/stm32mp2xx_hal.c)
 zephyr_library_sources(drivers/src/stm32mp2xx_hal_rcc.c)
 zephyr_library_sources(drivers/src/stm32mp2xx_hal_rcc_ex.c)


### PR DESCRIPTION
Stray changes to the CMakeLists for STM32MP2 series in commit a78b835ad50d71481033fbd39c6a33a8df74b22d cause a build failure because a non-existent file is taken as system source.

Revert the changes done by this commit to the CMakeLists.