### PR TITLE
RFC: Add a -pinctrl.dtsi generation validation action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,232 @@ name: Test
 on: [push, pull_request]
 
 jobs:
+  pinctrl-validation:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: check if pinctrl files were modified
+        id: changed
+        run: |
+          # Fetch the base commit so git diff can compare against it.
+          git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}"
+
+          # Determine whether any pinctrl-relevant path changed:
+          #   - dts/**/*.dtsi      : generated pinctrl files
+          #   - dts/README.rst     : documents the HAL1 (STM32_open_pin_data) revision
+          #   - scripts/genpinctrl : the generation scripts themselves
+          pinctrl_changed=false
+          if ! git diff --quiet "${{ github.event.pull_request.base.sha }}" HEAD -- \
+            ':(glob)dts/**/*.dtsi' \
+            'dts/README.rst' \
+            'scripts/genpinctrl'; then
+            pinctrl_changed=true
+          fi
+
+          # For HAL2-based series (those with a dfp/ subdirectory), a bump of the
+          # series README also requires regenerating the pinctrl files.
+          # HAL1-based series READMEs are unrelated to pinctrl generation and must
+          # not trigger this job unnecessarily.
+          if [ "$pinctrl_changed" = false ]; then
+            for readme in $(git diff --name-only \
+                "${{ github.event.pull_request.base.sha }}" HEAD \
+                -- ':(glob)stm32cube/*/README'); do
+              series_dir=$(dirname "$readme")
+              if [ -d "$series_dir/dfp" ]; then
+                pinctrl_changed=true
+                break
+              fi
+            done
+          fi
+
+          echo "pinctrl=$pinctrl_changed" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Python
+        if: steps.changed.outputs.pinctrl == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: install dependencies
+        if: steps.changed.outputs.pinctrl == 'true'
+        run: |
+          pip3 install -r scripts/requirements.txt
+
+      - name: get expected STM32 Open Pin Data commit
+        if: steps.changed.outputs.pinctrl == 'true'
+        id: opendata
+        run: |
+          # Read the pinned STM32_open_pin_data commit hash from the "Commit:"
+          # field documented in dts/README.rst (the line immediately after the key).
+          commit=$(awk '/^Commit:/{getline; gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0); print $0}' dts/README.rst)
+          if [ -z "$commit" ]; then
+            echo "Failed to find STM32 Open Pin Data commit in dts/README.rst"
+            exit 1
+          fi
+          echo "commit=$commit" >> "$GITHUB_OUTPUT"
+
+      - name: clone STM32 Open Pin Data
+        if: steps.changed.outputs.pinctrl == 'true'
+        run: |
+          git clone --depth 1 https://github.com/STMicroelectronics/STM32_open_pin_data.git /tmp/STM32_open_pin_data
+          git -C /tmp/STM32_open_pin_data fetch --depth 1 origin "${{ steps.opendata.outputs.commit }}"
+          git -C /tmp/STM32_open_pin_data checkout --detach "${{ steps.opendata.outputs.commit }}"
+
+      - name: clone STM32Cube DFP inputs
+        if: steps.changed.outputs.pinctrl == 'true'
+        run: |
+          mkdir -p /tmp/STM32Cube_DFP
+
+          # Each HAL2-capable series has a stm32cube/<series>/dfp/ directory.
+          # For each one, look up the pinned upstream commit from the series README,
+          # then resolve the DFP submodule URL and commit via the GitHub Contents API,
+          # and do a shallow clone of that exact commit.
+          for local_dfp in stm32cube/*/dfp; do
+            if [ ! -d "$local_dfp" ]; then
+              continue
+            fi
+
+            cube_dir=$(dirname "$local_dfp")
+            cube_name=$(basename "$cube_dir")
+            cube_readme="$cube_dir/README"
+            dfp_path="${cube_name}_dfp"
+
+            # Read the STM32Cube repo URL and commit hash documented in the series README.
+            cube_url=$(awk '/^URL:/{getline; gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0); print $0}' "$cube_readme")
+            cube_commit=$(awk '/^Commit:/{getline; gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0); print $0}' "$cube_readme")
+            if [ -z "$cube_url" ] || [ -z "$cube_commit" ]; then
+              echo "Failed to find STM32Cube URL or commit in $cube_readme"
+              exit 1
+            fi
+
+            # Query the GitHub Contents API to get the DFP submodule URL and commit
+            # at the documented STM32Cube revision.
+            cube_repo=${cube_url#https://github.com/}
+            cube_repo=${cube_repo%.git}
+            api_url="https://api.github.com/repos/$cube_repo/contents/$dfp_path?ref=$cube_commit"
+            curl -fsSL \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "$api_url" > /tmp/dfp.json
+
+            dfp_url=$(jq -r '.submodule_git_url // ""' /tmp/dfp.json)
+            dfp_commit=$(jq -r '.sha // ""' /tmp/dfp.json)
+            dfp_type=$(jq -r '.type // ""' /tmp/dfp.json)
+            if [ "$dfp_type" != "submodule" ] || [ -z "$dfp_url" ] || [ -z "$dfp_commit" ]; then
+              echo "Failed to find DFP submodule information for $cube_name"
+              exit 1
+            fi
+
+            # Shallow-clone the DFP repository at the exact resolved commit.
+            mkdir -p "/tmp/STM32Cube_DFP/$dfp_path"
+            git -C "/tmp/STM32Cube_DFP/$dfp_path" init -q
+            git -C "/tmp/STM32Cube_DFP/$dfp_path" remote add origin "$dfp_url"
+            git -C "/tmp/STM32Cube_DFP/$dfp_path" fetch --depth 1 origin "$dfp_commit"
+            git -C "/tmp/STM32Cube_DFP/$dfp_path" checkout --detach "$dfp_commit"
+          done
+
+      - name: regenerate pinctrl files (HAL1)
+        if: steps.changed.outputs.pinctrl == 'true'
+        run: |
+          python3 scripts/genpinctrl/genpinctrl.py -p /tmp/STM32_open_pin_data -o dts
+
+      - name: regenerate pinctrl files (HAL2)
+        if: steps.changed.outputs.pinctrl == 'true'
+        run: |
+          python3 scripts/genpinctrl/genpinctrl_hal2.py -p /tmp/STM32Cube_DFP -o dts
+
+      - name: restore documented pinctrl patches
+        if: steps.changed.outputs.pinctrl == 'true'
+        run: |
+          # The generation scripts also regenerate dts/README.rst; restore it so
+          # the patch-list parsing below reads the committed version, not the
+          # regenerated one.
+          git restore -- dts/README.rst
+
+          # Parse the "Patch List:" section from dts/README.rst to get the list
+          # of pinctrl files that are known to carry manual (non-generated) patches.
+          mapfile -t patched_patterns < <(
+            awk '
+              /^Patch List:/ { in_patch_list = 1; next }
+              in_patch_list && /^[[:space:]]*- Impacted files:/ { in_files = 1; next }
+              in_files && /^[[:space:]]*dts\/.*-pinctrl\.dtsi[[:space:]]*$/ {
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0);
+                print;
+                next;
+              }
+              in_files && /^[[:space:]]*$/ { in_files = 0 }
+            ' dts/README.rst
+          )
+
+          # Collect all pinctrl files that differ from the freshly regenerated output.
+          mapfile -t modified_pinctrl_files < <(
+            git diff --name-only -- ':(glob)dts/**/*-pinctrl.dtsi'
+          )
+
+          patched_files=()
+          missing_patterns=()
+
+          # For each documented patch entry, verify that regeneration actually
+          # produced a diff for that file (i.e. the patch is still relevant).
+          for pattern in "${patched_patterns[@]}"; do
+            matched=false
+
+            for modified_file in "${modified_pinctrl_files[@]}"; do
+              if [[ "$modified_file" == $pattern ]]; then
+                patched_files+=("$modified_file")
+                matched=true
+              fi
+            done
+
+            if [ "$matched" = false ]; then
+              missing_patterns+=("$pattern")
+            fi
+          done
+
+          # Abort if a documented patch entry no longer matches any regenerated diff:
+          # the patch may have been upstreamed or its file path may be stale.
+          if [ "${#missing_patterns[@]}" -gt 0 ]; then
+            echo "Documented pinctrl patch entries did not match any regenerated diff:"
+            printf '  - %s\n' "${missing_patterns[@]}"
+            echo
+            echo "The documented patch may no longer be needed, or its impacted"
+            echo "file path/pattern may be stale. Update dts/README.rst before"
+            echo "rerunning the pinctrl validation."
+            exit 1
+          fi
+
+          # Restore the committed (patched) version of each manually-patched file
+          # so that the final diff check ignores intentional divergences.
+          if [ "${#patched_files[@]}" -gt 0 ]; then
+            git restore -- "${patched_files[@]}"
+          fi
+
+      - name: validate generated files are up to date
+        if: steps.changed.outputs.pinctrl == 'true'
+        run: |
+          if ! git diff --quiet -- dts; then
+            echo "Pinctrl validation failed."
+            echo
+            echo "The workflow regenerated pinctrl files from the documented"
+            echo "input revisions and script configuration, taking the documented"
+            echo "Patch List into account."
+            echo "The generated files differ from the committed batch of"
+            echo "-pinctrl.dtsi files, which should not be the case."
+            echo
+            echo "Unexpected files still modified after regeneration:"
+            git --no-pager diff --name-status -- dts
+            echo
+            echo "Generated pinctrl diff summary:"
+            git --no-pager diff --stat -- ':(glob)dts/**/*.dtsi'
+            echo
+            echo "This usually means the generated pinctrl files are incomplete,"
+            echo "were generated from the wrong source revision, or include an"
+            echo "undocumented manual change."
+            exit 1
+          fi
+
   build:
     runs-on: ubuntu-latest
     strategy:

--- a/dts/st/c5/stm32c5(3-4)2c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(3-4)2c(b-c)tx-pinctrl.dtsi
@@ -640,6 +640,43 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
+	};
+
 	/* OPAMP */
 	/omit-if-no-ref/ opamp1_vout_pa6: opamp1_vout_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
@@ -665,72 +702,86 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb0: spi1_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb6: spi1_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa4: spi1_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa3: spi2_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb2: spi2_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -798,61 +849,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pb8: spi1_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa15: spi2_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa4: spi2_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(3-4)2c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(3-4)2c(b-c)ux-pinctrl.dtsi
@@ -640,6 +640,43 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
+	};
+
 	/* OPAMP */
 	/omit-if-no-ref/ opamp1_vout_pa6: opamp1_vout_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
@@ -665,72 +702,86 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb0: spi1_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb6: spi1_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa4: spi1_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa3: spi2_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb2: spi2_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -798,61 +849,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pb8: spi1_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa15: spi2_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa4: spi2_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(3-4)2e(b-c)ux-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(3-4)2e(b-c)ux-pinctrl.dtsi
@@ -462,6 +462,27 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
 	/* OPAMP */
 	/omit-if-no-ref/ opamp1_vout_pa6: opamp1_vout_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
@@ -471,57 +492,68 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb0: spi1_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa4: spi1_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa3: spi2_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb2: spi2_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -565,51 +597,61 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pb8: spi1_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa15: spi2_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa4: spi2_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(3-4)2f(b-c)px-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(3-4)2f(b-c)px-pinctrl.dtsi
@@ -404,6 +404,27 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
 	/* OPAMP */
 	/omit-if-no-ref/ opamp1_vout_pa6: opamp1_vout_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
@@ -413,52 +434,62 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb0: spi1_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa4: spi1_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa3: spi2_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb2: spi2_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -496,46 +527,55 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pb8: spi1_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa15: spi2_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa4: spi2_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(3-4)2f(b-c)ux-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(3-4)2f(b-c)ux-pinctrl.dtsi
@@ -404,6 +404,27 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
 	/* OPAMP */
 	/omit-if-no-ref/ opamp1_vout_pa6: opamp1_vout_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
@@ -413,52 +434,62 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb0: spi1_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa4: spi1_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa3: spi2_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb2: spi2_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -496,46 +527,55 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pb8: spi1_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa15: spi2_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa4: spi2_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(3-4)2k(b-c)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(3-4)2k(b-c)tx-pinctrl.dtsi
@@ -488,6 +488,23 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
 	/* OPAMP */
 	/omit-if-no-ref/ opamp1_vout_pa6: opamp1_vout_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
@@ -508,62 +525,74 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb0: spi1_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb6: spi1_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa4: spi1_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa3: spi2_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -607,46 +636,55 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pb8: spi1_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa15: spi2_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa4: spi2_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(3-4)2k(b-c)ux-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(3-4)2k(b-c)ux-pinctrl.dtsi
@@ -512,6 +512,27 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
+	};
+
 	/* OPAMP */
 	/omit-if-no-ref/ opamp1_vout_pa6: opamp1_vout_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
@@ -537,62 +558,74 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb0: spi1_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb6: spi1_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa4: spi1_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa3: spi2_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -636,51 +669,61 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pb8: spi1_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa15: spi2_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa4: spi2_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(3-4)2r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(3-4)2r(b-c)tx-pinctrl.dtsi
@@ -777,8 +777,61 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_traceswo_pb3: debug_traceswo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
 	};
 
 	/* OPAMP */
@@ -811,97 +864,116 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb0: spi1_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb6: spi1_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pc11: spi2_miso_pc11 {
 		pinmux = <STM32_PINMUX('C', 11, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa4: spi1_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa3: spi2_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb2: spi2_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 		pinmux = <STM32_PINMUX('C', 1, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc12: spi2_mosi_pc12 {
 		pinmux = <STM32_PINMUX('C', 12, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 		pinmux = <STM32_PINMUX('C', 3, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -975,61 +1047,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pb8: spi1_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa15: spi2_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa4: spi2_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(5-6)2c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(5-6)2c(c-e)tx-pinctrl.dtsi
@@ -654,6 +654,43 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
+	};
+
 	/* RCC_MCO */
 	/omit-if-no-ref/ rcc_mco1_pa8: rcc_mco1_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF0)>;
@@ -674,87 +711,104 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -840,61 +894,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(5-6)2c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(5-6)2c(c-e)ux-pinctrl.dtsi
@@ -654,6 +654,43 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
+	};
+
 	/* RCC_MCO */
 	/omit-if-no-ref/ rcc_mco1_pa8: rcc_mco1_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF0)>;
@@ -674,87 +711,104 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -840,61 +894,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(5-6)2k(c-e)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(5-6)2k(c-e)tx-pinctrl.dtsi
@@ -492,6 +492,23 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
 	/* RCC_MCO */
 	/omit-if-no-ref/ rcc_mco1_pa8: rcc_mco1_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF0)>;
@@ -507,77 +524,92 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -627,46 +659,55 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(5-6)2k(c-e)ux-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(5-6)2k(c-e)ux-pinctrl.dtsi
@@ -521,6 +521,27 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
+	};
+
 	/* RCC_MCO */
 	/omit-if-no-ref/ rcc_mco1_pa8: rcc_mco1_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF0)>;
@@ -541,77 +562,92 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -667,51 +703,61 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(5-6)2m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(5-6)2m(c-e)tx-pinctrl.dtsi
@@ -889,8 +889,81 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_traceswo_pb3: debug_traceswo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pd13: lptim1_ch1_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pe0: lptim1_etr_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe1: lptim1_in2_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
 	};
 
 	/* RCC_MCO */
@@ -918,112 +991,134 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pc11: spi3_miso_pc11 {
 		pinmux = <STM32_PINMUX('C', 11, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 		pinmux = <STM32_PINMUX('C', 1, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 		pinmux = <STM32_PINMUX('C', 3, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pc12: spi3_mosi_pc12 {
 		pinmux = <STM32_PINMUX('C', 12, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -1115,61 +1210,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(5-6)2r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(5-6)2r(c-e)tx-pinctrl.dtsi
@@ -803,8 +803,61 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_traceswo_pb3: debug_traceswo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
 	};
 
 	/* RCC_MCO */
@@ -832,112 +885,134 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pc11: spi3_miso_pc11 {
 		pinmux = <STM32_PINMUX('C', 11, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 		pinmux = <STM32_PINMUX('C', 1, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 		pinmux = <STM32_PINMUX('C', 3, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pc12: spi3_mosi_pc12 {
 		pinmux = <STM32_PINMUX('C', 12, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -1029,61 +1104,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(5-6)2v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(5-6)2v(c-e)tx-pinctrl.dtsi
@@ -1010,8 +1010,101 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_traceswo_pb3: debug_traceswo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pd13: lptim1_ch1_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pd10: lptim1_ch2_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pe0: lptim1_etr_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pd11: lptim1_in2_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe1: lptim1_in2_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
 	};
 
 	/* RCC_MCO */
@@ -1044,137 +1137,164 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pc11: spi3_miso_pc11 {
 		pinmux = <STM32_PINMUX('C', 11, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pd7: spi3_miso_pd7 {
 		pinmux = <STM32_PINMUX('D', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pe5: spi3_miso_pe5 {
 		pinmux = <STM32_PINMUX('E', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pd7: spi1_mosi_pd7 {
 		pinmux = <STM32_PINMUX('D', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 		pinmux = <STM32_PINMUX('C', 1, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 		pinmux = <STM32_PINMUX('C', 3, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pc12: spi3_mosi_pc12 {
 		pinmux = <STM32_PINMUX('C', 12, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pd6: spi3_mosi_pd6 {
 		pinmux = <STM32_PINMUX('D', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pe6: spi3_mosi_pe6 {
 		pinmux = <STM32_PINMUX('E', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -1272,66 +1392,79 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pe4: spi3_nss_pe4 {
 		pinmux = <STM32_PINMUX('E', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(9-a)3c(e-g)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(9-a)3c(e-g)tx-pinctrl.dtsi
@@ -670,6 +670,43 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
+	};
+
 	/* RCC_MCO */
 	/omit-if-no-ref/ rcc_mco1_pa8: rcc_mco1_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF0)>;
@@ -811,87 +848,104 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -977,61 +1031,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(9-a)3c(e-g)ux-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(9-a)3c(e-g)ux-pinctrl.dtsi
@@ -670,6 +670,43 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
+	};
+
 	/* RCC_MCO */
 	/omit-if-no-ref/ rcc_mco1_pa8: rcc_mco1_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF0)>;
@@ -811,87 +848,104 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -977,61 +1031,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(9-a)3k(e-g)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(9-a)3k(e-g)tx-pinctrl.dtsi
@@ -496,6 +496,23 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
 	/* RCC_MCO */
 	/omit-if-no-ref/ rcc_mco1_pa8: rcc_mco1_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF0)>;
@@ -592,77 +609,92 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -712,46 +744,55 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(9-a)3k(e-g)ux-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(9-a)3k(e-g)ux-pinctrl.dtsi
@@ -529,6 +529,27 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
+	};
+
 	/* RCC_MCO */
 	/omit-if-no-ref/ rcc_mco1_pa8: rcc_mco1_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF0)>;
@@ -635,77 +656,92 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -761,51 +797,61 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(9-a)3m(e-g)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(9-a)3m(e-g)tx-pinctrl.dtsi
@@ -1123,8 +1123,81 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_traceswo_pb3: debug_traceswo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pd13: lptim1_ch1_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pe0: lptim1_etr_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe1: lptim1_in2_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
 	};
 
 	/* RCC_MCO */
@@ -1408,112 +1481,134 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pc11: spi3_miso_pc11 {
 		pinmux = <STM32_PINMUX('C', 11, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 		pinmux = <STM32_PINMUX('C', 1, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 		pinmux = <STM32_PINMUX('C', 3, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pc12: spi3_mosi_pc12 {
 		pinmux = <STM32_PINMUX('C', 12, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -1605,61 +1700,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(9-a)3r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(9-a)3r(e-g)tx-pinctrl.dtsi
@@ -1007,8 +1007,61 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_traceswo_pb3: debug_traceswo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
 	};
 
 	/* RCC_MCO */
@@ -1247,112 +1300,134 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pc11: spi3_miso_pc11 {
 		pinmux = <STM32_PINMUX('C', 11, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 		pinmux = <STM32_PINMUX('C', 1, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 		pinmux = <STM32_PINMUX('C', 3, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pc12: spi3_mosi_pc12 {
 		pinmux = <STM32_PINMUX('C', 12, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -1444,61 +1519,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(9-a)3v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(9-a)3v(e-g)tx-pinctrl.dtsi
@@ -1322,8 +1322,101 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_traceswo_pb3: debug_traceswo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pd13: lptim1_ch1_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pd10: lptim1_ch2_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pe0: lptim1_etr_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pd11: lptim1_in2_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe1: lptim1_in2_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
 	};
 
 	/* RCC_MCO */
@@ -1642,137 +1735,164 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pc11: spi3_miso_pc11 {
 		pinmux = <STM32_PINMUX('C', 11, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pd7: spi3_miso_pd7 {
 		pinmux = <STM32_PINMUX('D', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pe5: spi3_miso_pe5 {
 		pinmux = <STM32_PINMUX('E', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pd7: spi1_mosi_pd7 {
 		pinmux = <STM32_PINMUX('D', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 		pinmux = <STM32_PINMUX('C', 1, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 		pinmux = <STM32_PINMUX('C', 3, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pc12: spi3_mosi_pc12 {
 		pinmux = <STM32_PINMUX('C', 12, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pd6: spi3_mosi_pd6 {
 		pinmux = <STM32_PINMUX('D', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pe6: spi3_mosi_pe6 {
 		pinmux = <STM32_PINMUX('E', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -1870,66 +1990,79 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pe4: spi3_nss_pe4 {
 		pinmux = <STM32_PINMUX('E', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c5(9-a)3z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c5(9-a)3z(e-g)tx-pinctrl.dtsi
@@ -1568,8 +1568,129 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_traceswo_pb3: debug_traceswo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pd13: lptim1_ch1_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pg13: lptim1_ch1_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pd10: lptim1_ch2_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pg14: lptim1_ch2_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pe0: lptim1_etr_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pg14: lptim1_etr_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pg12: lptim1_in1_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pd11: lptim1_in2_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe1: lptim1_in2_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pg11: lptim1_in2_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
 	};
 
 	/* RCC_MCO */
@@ -1933,152 +2054,182 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pg9: spi1_miso_pg9 {
 		pinmux = <STM32_PINMUX('G', 9, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pc11: spi3_miso_pc11 {
 		pinmux = <STM32_PINMUX('C', 11, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pd7: spi3_miso_pd7 {
 		pinmux = <STM32_PINMUX('D', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pe5: spi3_miso_pe5 {
 		pinmux = <STM32_PINMUX('E', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pd7: spi1_mosi_pd7 {
 		pinmux = <STM32_PINMUX('D', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 		pinmux = <STM32_PINMUX('C', 1, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 		pinmux = <STM32_PINMUX('C', 3, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pg1: spi2_mosi_pg1 {
 		pinmux = <STM32_PINMUX('G', 1, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pc12: spi3_mosi_pc12 {
 		pinmux = <STM32_PINMUX('C', 12, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pd6: spi3_mosi_pd6 {
 		pinmux = <STM32_PINMUX('D', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pe6: spi3_mosi_pe6 {
 		pinmux = <STM32_PINMUX('E', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pg8: spi3_mosi_pg8 {
 		pinmux = <STM32_PINMUX('G', 8, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -2182,71 +2333,85 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pg10: spi1_nss_pg10 {
 		pinmux = <STM32_PINMUX('G', 10, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pe4: spi3_nss_pe4 {
 		pinmux = <STM32_PINMUX('E', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c531c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c531c(b-c)tx-pinctrl.dtsi
@@ -578,6 +578,43 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
+	};
+
 	/* OPAMP */
 	/omit-if-no-ref/ opamp1_vout_pa6: opamp1_vout_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
@@ -603,72 +640,86 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb0: spi1_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb6: spi1_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa4: spi1_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa3: spi2_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb2: spi2_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -736,61 +787,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pb8: spi1_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa15: spi2_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa4: spi2_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c531c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/c5/stm32c531c(b-c)ux-pinctrl.dtsi
@@ -578,6 +578,43 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
+	};
+
 	/* OPAMP */
 	/omit-if-no-ref/ opamp1_vout_pa6: opamp1_vout_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
@@ -603,72 +640,86 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb0: spi1_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb6: spi1_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa4: spi1_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa3: spi2_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb2: spi2_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -736,61 +787,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pb8: spi1_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa15: spi2_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa4: spi2_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c531e(b-c)ux-pinctrl.dtsi
+++ b/dts/st/c5/stm32c531e(b-c)ux-pinctrl.dtsi
@@ -432,6 +432,27 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
 	/* OPAMP */
 	/omit-if-no-ref/ opamp1_vout_pa6: opamp1_vout_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
@@ -441,57 +462,68 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb0: spi1_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa4: spi1_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa3: spi2_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb2: spi2_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -535,51 +567,61 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pb8: spi1_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa15: spi2_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa4: spi2_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c531f(b-c)px-pinctrl.dtsi
+++ b/dts/st/c5/stm32c531f(b-c)px-pinctrl.dtsi
@@ -382,6 +382,27 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
 	/* OPAMP */
 	/omit-if-no-ref/ opamp1_vout_pa6: opamp1_vout_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
@@ -391,52 +412,62 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb0: spi1_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa4: spi1_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa3: spi2_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb2: spi2_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -474,46 +505,55 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pb8: spi1_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa15: spi2_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa4: spi2_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c531f(b-c)ux-pinctrl.dtsi
+++ b/dts/st/c5/stm32c531f(b-c)ux-pinctrl.dtsi
@@ -382,6 +382,27 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
 	/* OPAMP */
 	/omit-if-no-ref/ opamp1_vout_pa6: opamp1_vout_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
@@ -391,52 +412,62 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb0: spi1_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa4: spi1_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa3: spi2_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb2: spi2_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -474,46 +505,55 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pb8: spi1_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa15: spi2_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa4: spi2_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c531k(b-c)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c531k(b-c)tx-pinctrl.dtsi
@@ -450,6 +450,23 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
 	/* OPAMP */
 	/omit-if-no-ref/ opamp1_vout_pa6: opamp1_vout_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
@@ -470,62 +487,74 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb0: spi1_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb6: spi1_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa4: spi1_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa3: spi2_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -569,46 +598,55 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pb8: spi1_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa15: spi2_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa4: spi2_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c531k(b-c)ux-pinctrl.dtsi
+++ b/dts/st/c5/stm32c531k(b-c)ux-pinctrl.dtsi
@@ -470,6 +470,27 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
+	};
+
 	/* OPAMP */
 	/omit-if-no-ref/ opamp1_vout_pa6: opamp1_vout_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
@@ -495,62 +516,74 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb0: spi1_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb6: spi1_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa4: spi1_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa3: spi2_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -594,51 +627,61 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pb8: spi1_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa15: spi2_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa4: spi2_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c531r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c531r(b-c)tx-pinctrl.dtsi
@@ -715,8 +715,61 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_traceswo_pb3: debug_traceswo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
 	};
 
 	/* OPAMP */
@@ -749,97 +802,116 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb0: spi1_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb6: spi1_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pc11: spi2_miso_pc11 {
 		pinmux = <STM32_PINMUX('C', 11, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa4: spi1_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa3: spi2_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb2: spi2_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 		pinmux = <STM32_PINMUX('C', 1, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc12: spi2_mosi_pc12 {
 		pinmux = <STM32_PINMUX('C', 12, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 		pinmux = <STM32_PINMUX('C', 3, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -913,61 +985,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pb8: spi1_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa15: spi2_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa4: spi2_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c551c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c551c(c-e)tx-pinctrl.dtsi
@@ -604,6 +604,43 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
+	};
+
 	/* RCC_MCO */
 	/omit-if-no-ref/ rcc_mco1_pa8: rcc_mco1_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF0)>;
@@ -624,87 +661,104 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -790,61 +844,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c551c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/c5/stm32c551c(c-e)ux-pinctrl.dtsi
@@ -604,6 +604,43 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
+	};
+
 	/* RCC_MCO */
 	/omit-if-no-ref/ rcc_mco1_pa8: rcc_mco1_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF0)>;
@@ -624,87 +661,104 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -790,61 +844,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c551k(c-e)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c551k(c-e)tx-pinctrl.dtsi
@@ -462,6 +462,23 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
 	/* RCC_MCO */
 	/omit-if-no-ref/ rcc_mco1_pa8: rcc_mco1_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF0)>;
@@ -477,77 +494,92 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -597,46 +629,55 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c551k(c-e)ux-pinctrl.dtsi
+++ b/dts/st/c5/stm32c551k(c-e)ux-pinctrl.dtsi
@@ -487,6 +487,27 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
+	};
+
 	/* RCC_MCO */
 	/omit-if-no-ref/ rcc_mco1_pa8: rcc_mco1_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF0)>;
@@ -507,77 +528,92 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -633,51 +669,61 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c551m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c551m(c-e)tx-pinctrl.dtsi
@@ -823,8 +823,81 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_traceswo_pb3: debug_traceswo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pd13: lptim1_ch1_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pe0: lptim1_etr_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe1: lptim1_in2_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
 	};
 
 	/* RCC_MCO */
@@ -852,112 +925,134 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pc11: spi3_miso_pc11 {
 		pinmux = <STM32_PINMUX('C', 11, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 		pinmux = <STM32_PINMUX('C', 1, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 		pinmux = <STM32_PINMUX('C', 3, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pc12: spi3_mosi_pc12 {
 		pinmux = <STM32_PINMUX('C', 12, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -1049,61 +1144,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c551r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c551r(c-e)tx-pinctrl.dtsi
@@ -753,8 +753,61 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_traceswo_pb3: debug_traceswo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
 	};
 
 	/* RCC_MCO */
@@ -782,112 +835,134 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pc11: spi3_miso_pc11 {
 		pinmux = <STM32_PINMUX('C', 11, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 		pinmux = <STM32_PINMUX('C', 1, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 		pinmux = <STM32_PINMUX('C', 3, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pc12: spi3_mosi_pc12 {
 		pinmux = <STM32_PINMUX('C', 12, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -979,61 +1054,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c551v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c551v(c-e)tx-pinctrl.dtsi
@@ -940,8 +940,101 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_traceswo_pb3: debug_traceswo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pd13: lptim1_ch1_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pd10: lptim1_ch2_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pe0: lptim1_etr_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pd11: lptim1_in2_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe1: lptim1_in2_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
 	};
 
 	/* RCC_MCO */
@@ -974,137 +1067,164 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pc11: spi3_miso_pc11 {
 		pinmux = <STM32_PINMUX('C', 11, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pd7: spi3_miso_pd7 {
 		pinmux = <STM32_PINMUX('D', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pe5: spi3_miso_pe5 {
 		pinmux = <STM32_PINMUX('E', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pd7: spi1_mosi_pd7 {
 		pinmux = <STM32_PINMUX('D', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 		pinmux = <STM32_PINMUX('C', 1, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 		pinmux = <STM32_PINMUX('C', 3, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pc12: spi3_mosi_pc12 {
 		pinmux = <STM32_PINMUX('C', 12, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pd6: spi3_mosi_pd6 {
 		pinmux = <STM32_PINMUX('D', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pe6: spi3_mosi_pe6 {
 		pinmux = <STM32_PINMUX('E', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -1202,66 +1322,79 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pe4: spi3_nss_pe4 {
 		pinmux = <STM32_PINMUX('E', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c591c(e-g)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c591c(e-g)tx-pinctrl.dtsi
@@ -616,6 +616,43 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
+	};
+
 	/* RCC_MCO */
 	/omit-if-no-ref/ rcc_mco1_pa8: rcc_mco1_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF0)>;
@@ -757,87 +794,104 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -923,61 +977,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c591c(e-g)ux-pinctrl.dtsi
+++ b/dts/st/c5/stm32c591c(e-g)ux-pinctrl.dtsi
@@ -616,6 +616,43 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
+	};
+
 	/* RCC_MCO */
 	/omit-if-no-ref/ rcc_mco1_pa8: rcc_mco1_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF0)>;
@@ -757,87 +794,104 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -923,61 +977,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c591k(e-g)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c591k(e-g)tx-pinctrl.dtsi
@@ -466,6 +466,23 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
 	/* RCC_MCO */
 	/omit-if-no-ref/ rcc_mco1_pa8: rcc_mco1_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF0)>;
@@ -562,77 +579,92 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -682,46 +714,55 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c591k(e-g)ux-pinctrl.dtsi
+++ b/dts/st/c5/stm32c591k(e-g)ux-pinctrl.dtsi
@@ -495,6 +495,27 @@
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
 	};
 
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
+	};
+
 	/* RCC_MCO */
 	/omit-if-no-ref/ rcc_mco1_pa8: rcc_mco1_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF0)>;
@@ -601,77 +622,92 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -727,51 +763,61 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c591m(e-g)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c591m(e-g)tx-pinctrl.dtsi
@@ -855,8 +855,81 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_traceswo_pb3: debug_traceswo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pd13: lptim1_ch1_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pe0: lptim1_etr_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe1: lptim1_in2_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
 	};
 
 	/* RCC_MCO */
@@ -1140,112 +1213,134 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pc11: spi3_miso_pc11 {
 		pinmux = <STM32_PINMUX('C', 11, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 		pinmux = <STM32_PINMUX('C', 1, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 		pinmux = <STM32_PINMUX('C', 3, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pc12: spi3_mosi_pc12 {
 		pinmux = <STM32_PINMUX('C', 12, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -1337,61 +1432,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c591r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c591r(e-g)tx-pinctrl.dtsi
@@ -765,8 +765,61 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_traceswo_pb3: debug_traceswo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
 	};
 
 	/* RCC_MCO */
@@ -1005,112 +1058,134 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pc11: spi3_miso_pc11 {
 		pinmux = <STM32_PINMUX('C', 11, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 		pinmux = <STM32_PINMUX('C', 1, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 		pinmux = <STM32_PINMUX('C', 3, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pc12: spi3_mosi_pc12 {
 		pinmux = <STM32_PINMUX('C', 12, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -1202,61 +1277,73 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c591v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c591v(e-g)tx-pinctrl.dtsi
@@ -996,8 +996,101 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_traceswo_pb3: debug_traceswo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pd13: lptim1_ch1_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pd10: lptim1_ch2_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pe0: lptim1_etr_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pd11: lptim1_in2_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe1: lptim1_in2_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
 	};
 
 	/* RCC_MCO */
@@ -1316,137 +1409,164 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pc11: spi3_miso_pc11 {
 		pinmux = <STM32_PINMUX('C', 11, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pd7: spi3_miso_pd7 {
 		pinmux = <STM32_PINMUX('D', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pe5: spi3_miso_pe5 {
 		pinmux = <STM32_PINMUX('E', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pd7: spi1_mosi_pd7 {
 		pinmux = <STM32_PINMUX('D', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 		pinmux = <STM32_PINMUX('C', 1, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 		pinmux = <STM32_PINMUX('C', 3, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pc12: spi3_mosi_pc12 {
 		pinmux = <STM32_PINMUX('C', 12, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pd6: spi3_mosi_pd6 {
 		pinmux = <STM32_PINMUX('D', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pe6: spi3_mosi_pe6 {
 		pinmux = <STM32_PINMUX('E', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -1544,66 +1664,79 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pe4: spi3_nss_pe4 {
 		pinmux = <STM32_PINMUX('E', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */

--- a/dts/st/c5/stm32c591z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/c5/stm32c591z(e-g)tx-pinctrl.dtsi
@@ -1182,8 +1182,129 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/omit-if-no-ref/ debug_traced0_pc1: debug_traced0_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pe3: debug_traced0_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced0_pg13: debug_traced0_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pc8: debug_traced1_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pe4: debug_traced1_pe4 {
+		pinmux = <STM32_PINMUX('E', 4, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced1_pg14: debug_traced1_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pd2: debug_traced2_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced2_pe5: debug_traced2_pe5 {
+		pinmux = <STM32_PINMUX('E', 5, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pc12: debug_traced3_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF0)>;
+	};
+
+	/omit-if-no-ref/ debug_traced3_pe6: debug_traced3_pe6 {
+		pinmux = <STM32_PINMUX('E', 6, AF0)>;
+	};
+
 	/omit-if-no-ref/ debug_traceswo_pb3: debug_traceswo_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF0)>;
+	};
+
+	/* LPTIM */
+	/omit-if-no-ref/ lptim1_ch1_pb13: lptim1_ch1_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pb2: lptim1_ch1_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pd13: lptim1_ch1_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch1_pg13: lptim1_ch1_pg13 {
+		pinmux = <STM32_PINMUX('G', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pb4: lptim1_ch2_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pd10: lptim1_ch2_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_ch2_pg14: lptim1_ch2_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF4)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pa15: lptim1_etr_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pe0: lptim1_etr_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_etr_pg14: lptim1_etr_pg14 {
+		pinmux = <STM32_PINMUX('G', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pa1: lptim1_in1_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pb10: lptim1_in1_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF3)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pd12: lptim1_in1_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in1_pg12: lptim1_in1_pg12 {
+		pinmux = <STM32_PINMUX('G', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pa2: lptim1_in2_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF5)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pd11: lptim1_in2_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe1: lptim1_in2_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pe2: lptim1_in2_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_pg11: lptim1_in2_pg11 {
+		pinmux = <STM32_PINMUX('G', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lptim1_in2_ph2: lptim1_in2_ph2 {
+		pinmux = <STM32_PINMUX('H', 2, AF3)>;
 	};
 
 	/* RCC_MCO */
@@ -1547,152 +1668,182 @@
 	/omit-if-no-ref/ spi1_miso_pa6: spi1_miso_pa6 {
 		pinmux = <STM32_PINMUX('A', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pb4: spi1_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_miso_pg9: spi1_miso_pg9 {
 		pinmux = <STM32_PINMUX('G', 9, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pa7: spi2_miso_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pb14: spi2_miso_pb14 {
 		pinmux = <STM32_PINMUX('B', 14, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb0: spi3_miso_pb0 {
 		pinmux = <STM32_PINMUX('B', 0, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pb6: spi3_miso_pb6 {
 		pinmux = <STM32_PINMUX('B', 6, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pc11: spi3_miso_pc11 {
 		pinmux = <STM32_PINMUX('C', 11, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pd7: spi3_miso_pd7 {
 		pinmux = <STM32_PINMUX('D', 7, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_miso_pe5: spi3_miso_pe5 {
 		pinmux = <STM32_PINMUX('E', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_MOSI */
 	/omit-if-no-ref/ spi1_mosi_pa7: spi1_mosi_pa7 {
 		pinmux = <STM32_PINMUX('A', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb15: spi1_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pb5: spi1_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_mosi_pd7: spi1_mosi_pd7 {
 		pinmux = <STM32_PINMUX('D', 7, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pa8: spi2_mosi_pa8 {
 		pinmux = <STM32_PINMUX('A', 8, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pb15: spi2_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 		pinmux = <STM32_PINMUX('C', 1, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 		pinmux = <STM32_PINMUX('C', 3, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_mosi_pg1: spi2_mosi_pg1 {
 		pinmux = <STM32_PINMUX('G', 1, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa3: spi3_mosi_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pa4: spi3_mosi_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF4)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb15: spi3_mosi_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb2: spi3_mosi_pb2 {
 		pinmux = <STM32_PINMUX('B', 2, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pb5: spi3_mosi_pb5 {
 		pinmux = <STM32_PINMUX('B', 5, AF7)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pc12: spi3_mosi_pc12 {
 		pinmux = <STM32_PINMUX('C', 12, AF6)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pd6: spi3_mosi_pd6 {
 		pinmux = <STM32_PINMUX('D', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pe6: spi3_mosi_pe6 {
 		pinmux = <STM32_PINMUX('E', 6, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_mosi_pg8: spi3_mosi_pg8 {
 		pinmux = <STM32_PINMUX('G', 8, AF5)>;
 		bias-pull-down;
+		slew-rate = "very-high-speed";
 	};
 
 	/* SPI_SCK */
@@ -1796,71 +1947,85 @@
 	/omit-if-no-ref/ spi1_nss_pa15: spi1_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pa4: spi1_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi1_nss_pg10: spi1_nss_pg10 {
 		pinmux = <STM32_PINMUX('G', 10, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa0: spi2_nss_pa0 {
 		pinmux = <STM32_PINMUX('A', 0, AF9)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa11: spi2_nss_pa11 {
 		pinmux = <STM32_PINMUX('A', 11, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pa3: spi2_nss_pa3 {
 		pinmux = <STM32_PINMUX('A', 3, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb1: spi2_nss_pb1 {
 		pinmux = <STM32_PINMUX('B', 1, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb12: spi2_nss_pb12 {
 		pinmux = <STM32_PINMUX('B', 12, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb4: spi2_nss_pb4 {
 		pinmux = <STM32_PINMUX('B', 4, AF7)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi2_nss_pb9: spi2_nss_pb9 {
 		pinmux = <STM32_PINMUX('B', 9, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa15: spi3_nss_pa15 {
 		pinmux = <STM32_PINMUX('A', 15, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pa4: spi3_nss_pa4 {
 		pinmux = <STM32_PINMUX('A', 4, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pb8: spi3_nss_pb8 {
 		pinmux = <STM32_PINMUX('B', 8, AF6)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/omit-if-no-ref/ spi3_nss_pe4: spi3_nss_pe4 {
 		pinmux = <STM32_PINMUX('E', 4, AF5)>;
 		bias-pull-up;
+		slew-rate = "very-high-speed";
 	};
 
 	/* TIM_BKIN */


### PR DESCRIPTION
Aim of the action is to validate state of the -pinctrl.dtsi files if they are modified.

This should provide an easy way for maintainer to verify that pinctrl.dtsi files have been modified and documented according to the rules. It also provides a quick feedback to contributors on their changes

The action is triggered in the PR touching these files, config files or README files that document the versions of the input components.
When triggered it  will generate a new set of -pcintrl.dtsi files based on the documented versions of STM32_open_pin_data (HAL1) and DFP (HAL2). After generation, it checks that there is no difference with the commited version.
If differences are found, an error is generated.

The script is also able to take into account patches documented in README files, and in that case, it only checks that a difference is available in the documented files, but isn't able to verify the nature of the difference.

Since the script is looking for information (repo versions, patched files) in the README files that are not strictly structured, there is a fragility on this part. TBD if acceptable or if we should move to another way to document those in a more binding way (.yaml file for instance), which would be a more impacting change. 