### PR TITLE
stm32cube: h5/h7rs/u3/u5/mp2/n6: Fix HAL_MDF_IRQHandler

### DIFF
--- a/stm32cube/stm32h5xx/README
+++ b/stm32cube/stm32h5xx/README
@@ -80,4 +80,12 @@ Patch List:
       stm32cube/stm32h5xx/drivers/include/stm32h5xx_hal_mdf.h
      ST internal bug : HAL1-27445
 
+   *Fix HAL_MDF_IRQHandler
+      HAL_MDF_IRQHandler handles IRQ flags in an if {} else if {} condition.
+      This causes interrupts to be handled once and only the first flag
+      encountered in the condition, while there can be several flags raised.
+     Impacted files:
+       drivers/src/stm32h5xx_hal_mdf.c
+     ST Internal Reference: HAL1-27843
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32h5xx/drivers/src/stm32h5xx_hal_mdf.c
+++ b/stm32cube/stm32h5xx/drivers/src/stm32h5xx_hal_mdf.c
@@ -3036,7 +3036,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if snapshot overrun occurs */
-  else if ((interrupts & MDF_DFLTISR_SSOVRF) == MDF_DFLTISR_SSOVRF)
+  if ((interrupts & MDF_DFLTISR_SSOVRF) == MDF_DFLTISR_SSOVRF)
   {
     /* Clear snapshot overrun flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SSOVRF;
@@ -3052,7 +3052,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if RXFIFO threshold occurs */
-  else if ((interrupts & MDF_DFLTISR_FTHF) == MDF_DFLTISR_FTHF)
+  if ((interrupts & MDF_DFLTISR_FTHF) == MDF_DFLTISR_FTHF)
   {
     /* Call acquisition complete callback */
 #if (USE_HAL_MDF_REGISTER_CALLBACKS == 1)
@@ -3068,7 +3068,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
     }
   }
   /* Check if snapshot data ready occurs */
-  else if ((interrupts & MDF_DFLTISR_SSDRF) == MDF_DFLTISR_SSDRF)
+  if ((interrupts & MDF_DFLTISR_SSDRF) == MDF_DFLTISR_SSDRF)
   {
     /* Clear snapshot data ready flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SSDRF;
@@ -3081,7 +3081,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if reshape filter overrun occurs */
-  else if ((interrupts & MDF_DFLTISR_RFOVRF) == MDF_DFLTISR_RFOVRF)
+  if ((interrupts & MDF_DFLTISR_RFOVRF) == MDF_DFLTISR_RFOVRF)
   {
     /* Clear reshape filter overrun flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_RFOVRF;
@@ -3097,7 +3097,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if clock absence detection occurs */
-  else if ((interrupts & MDF_DFLTISR_CKABF) == MDF_DFLTISR_CKABF)
+  if ((interrupts & MDF_DFLTISR_CKABF) == MDF_DFLTISR_CKABF)
   {
     /* Clear clock absence detection flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_CKABF;
@@ -3113,7 +3113,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if saturation occurs */
-  else if ((interrupts & MDF_DFLTISR_SATF) == MDF_DFLTISR_SATF)
+  if ((interrupts & MDF_DFLTISR_SATF) == MDF_DFLTISR_SATF)
   {
     /* Clear saturation flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SATF;
@@ -3129,7 +3129,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if short-circuit detection occurs */
-  else if ((interrupts & MDF_DFLTISR_SCDF) == MDF_DFLTISR_SCDF)
+  if ((interrupts & MDF_DFLTISR_SCDF) == MDF_DFLTISR_SCDF)
   {
     /* Clear short-circuit detection flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SCDF;
@@ -3145,7 +3145,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if out-off limit detection occurs */
-  else if ((interrupts & MDF_DFLTISR_OLDF) == MDF_DFLTISR_OLDF)
+  if ((interrupts & MDF_DFLTISR_OLDF) == MDF_DFLTISR_OLDF)
   {
     uint32_t threshold_info;
 
@@ -3177,7 +3177,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if sound activity detection occurs */
-  else if ((interrupts & MDF_DFLTISR_SDDETF) == MDF_DFLTISR_SDDETF)
+  if ((interrupts & MDF_DFLTISR_SDDETF) == MDF_DFLTISR_SDDETF)
   {
     /* Clear sound activity detection flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SDDETF;
@@ -3189,30 +3189,27 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
     HAL_MDF_SadCallback(hmdf);
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
-  else
+  /* Check if sound level ready occurs */
+  if ((interrupts & MDF_DFLTISR_SDLVLF) == MDF_DFLTISR_SDLVLF)
   {
-    /* Check if sound level ready occurs */
-    if ((interrupts & MDF_DFLTISR_SDLVLF) == MDF_DFLTISR_SDLVLF)
-    {
-      uint32_t sound_level;
-      uint32_t ambient_noise;
+    uint32_t sound_level;
+    uint32_t ambient_noise;
 
-      /* Get sound level */
-      sound_level = hmdf->Instance->SADSDLVR;
+    /* Get sound level */
+    sound_level = hmdf->Instance->SADSDLVR;
 
-      /* Get ambient noise */
-      ambient_noise = hmdf->Instance->SADANLVR;
+    /* Get ambient noise */
+    ambient_noise = hmdf->Instance->SADANLVR;
 
-      /* Clear sound level ready flag */
-      hmdf->Instance->DFLTISR |= MDF_DFLTISR_SDLVLF;
+    /* Clear sound level ready flag */
+    hmdf->Instance->DFLTISR |= MDF_DFLTISR_SDLVLF;
 
-      /* Call sound level callback */
+    /* Call sound level callback */
 #if (USE_HAL_MDF_REGISTER_CALLBACKS == 1)
-      hmdf->SndLvCallback(hmdf, sound_level, ambient_noise);
+    hmdf->SndLvCallback(hmdf, sound_level, ambient_noise);
 #else /* USE_HAL_MDF_REGISTER_CALLBACKS */
-      HAL_MDF_SndLvlCallback(hmdf, sound_level, ambient_noise);
+    HAL_MDF_SndLvlCallback(hmdf, sound_level, ambient_noise);
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
-    }
   }
 }
 

--- a/stm32cube/stm32h7rsxx/README
+++ b/stm32cube/stm32h7rsxx/README
@@ -76,4 +76,12 @@ Patch List:
      See also:
       https://github.com/zephyrproject-rtos/hal_stm32/pull/304
 
+   *Fix HAL_MDF_IRQHandler
+      HAL_MDF_IRQHandler handles IRQ flags in an if {} else if {} condition.
+      This causes interrupts to be handled once and only the first flag
+      encountered in the condition, while there can be several flags raised.
+     Impacted files:
+       drivers/src/stm32h7rsxx_hal_mdf.c
+     ST Internal Reference: HAL1-27843
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32h7rsxx/drivers/src/stm32h7rsxx_hal_mdf.c
+++ b/stm32cube/stm32h7rsxx/drivers/src/stm32h7rsxx_hal_mdf.c
@@ -1857,7 +1857,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if RXFIFO threshold occurs */
-  else if ((interrupts & MDF_DFLTISR_FTHF) == MDF_DFLTISR_FTHF)
+  if ((interrupts & MDF_DFLTISR_FTHF) == MDF_DFLTISR_FTHF)
   {
     /* Call acquisition complete callback */
 #if (USE_HAL_MDF_REGISTER_CALLBACKS == 1)
@@ -1873,7 +1873,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
     }
   }
   /* Check if reshape filter overrun occurs */
-  else if ((interrupts & MDF_DFLTISR_RFOVRF) == MDF_DFLTISR_RFOVRF)
+  if ((interrupts & MDF_DFLTISR_RFOVRF) == MDF_DFLTISR_RFOVRF)
   {
     /* Clear reshape filter overrun flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_RFOVRF;
@@ -1889,7 +1889,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if clock absence detection occurs */
-  else if ((interrupts & MDF_DFLTISR_CKABF) == MDF_DFLTISR_CKABF)
+  if ((interrupts & MDF_DFLTISR_CKABF) == MDF_DFLTISR_CKABF)
   {
     /* Clear clock absence detection flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_CKABF;
@@ -1905,7 +1905,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if saturation occurs */
-  else if ((interrupts & MDF_DFLTISR_SATF) == MDF_DFLTISR_SATF)
+  if ((interrupts & MDF_DFLTISR_SATF) == MDF_DFLTISR_SATF)
   {
     /* Clear saturation flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SATF;
@@ -1921,7 +1921,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if sound activity detection occurs */
-  else if ((interrupts & MDF_DFLTISR_SDDETF) == MDF_DFLTISR_SDDETF)
+  if ((interrupts & MDF_DFLTISR_SDDETF) == MDF_DFLTISR_SDDETF)
   {
     /* Clear sound activity detection flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SDDETF;
@@ -1933,30 +1933,27 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
     HAL_MDF_SadCallback(hmdf);
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
-  else
+  /* Check if sound level ready occurs */
+  if ((interrupts & MDF_DFLTISR_SDLVLF) == MDF_DFLTISR_SDLVLF)
   {
-    /* Check if sound level ready occurs */
-    if ((interrupts & MDF_DFLTISR_SDLVLF) == MDF_DFLTISR_SDLVLF)
-    {
-      uint32_t sound_level;
-      uint32_t ambient_noise;
+    uint32_t sound_level;
+    uint32_t ambient_noise;
 
-      /* Get sound level */
-      sound_level = hmdf->Instance->SADSDLVR;
+    /* Get sound level */
+    sound_level = hmdf->Instance->SADSDLVR;
 
-      /* Get ambient noise */
-      ambient_noise = hmdf->Instance->SADANLVR;
+    /* Get ambient noise */
+    ambient_noise = hmdf->Instance->SADANLVR;
 
-      /* Clear sound level ready flag */
-      hmdf->Instance->DFLTISR |= MDF_DFLTISR_SDLVLF;
+    /* Clear sound level ready flag */
+    hmdf->Instance->DFLTISR |= MDF_DFLTISR_SDLVLF;
 
-      /* Call sound level callback */
+    /* Call sound level callback */
 #if (USE_HAL_MDF_REGISTER_CALLBACKS == 1)
-      hmdf->SndLvCallback(hmdf, sound_level, ambient_noise);
+    hmdf->SndLvCallback(hmdf, sound_level, ambient_noise);
 #else /* USE_HAL_MDF_REGISTER_CALLBACKS */
-      HAL_MDF_SndLvlCallback(hmdf, sound_level, ambient_noise);
+    HAL_MDF_SndLvlCallback(hmdf, sound_level, ambient_noise);
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
-    }
   }
 }
 

--- a/stm32cube/stm32mp2xx/README
+++ b/stm32cube/stm32mp2xx/README
@@ -82,4 +82,12 @@ Patch List:
       drivers/include/stm32mp2xx_hal_eth.h
      Internal reference: 220075
 
+   *Fix HAL_MDF_IRQHandler
+      HAL_MDF_IRQHandler handles IRQ flags in an if {} else if {} condition.
+      This causes interrupts to be handled once and only the first flag
+      encountered in the condition, while there can be several flags raised.
+     Impacted files:
+       drivers/src/stm32mp2xx_hal_mdf.c
+     ST Internal Reference: HAL1-27843
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32mp2xx/drivers/src/stm32mp2xx_hal_mdf.c
+++ b/stm32cube/stm32mp2xx/drivers/src/stm32mp2xx_hal_mdf.c
@@ -3046,7 +3046,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if snapshot overrun occurs */
-  else if ((interrupts & MDF_DFLTISR_SSOVRF) == MDF_DFLTISR_SSOVRF)
+  if ((interrupts & MDF_DFLTISR_SSOVRF) == MDF_DFLTISR_SSOVRF)
   {
     /* Clear snapshot overrun flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SSOVRF;
@@ -3062,7 +3062,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if RXFIFO threshold occurs */
-  else if ((interrupts & MDF_DFLTISR_FTHF) == MDF_DFLTISR_FTHF)
+  if ((interrupts & MDF_DFLTISR_FTHF) == MDF_DFLTISR_FTHF)
   {
     /* Call acquisition complete callback */
 #if (USE_HAL_MDF_REGISTER_CALLBACKS == 1)
@@ -3078,7 +3078,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
     }
   }
   /* Check if snapshot data ready occurs */
-  else if ((interrupts & MDF_DFLTISR_SSDRF) == MDF_DFLTISR_SSDRF)
+  if ((interrupts & MDF_DFLTISR_SSDRF) == MDF_DFLTISR_SSDRF)
   {
     /* Clear snapshot data ready flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SSDRF;
@@ -3091,7 +3091,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if reshape filter overrun occurs */
-  else if ((interrupts & MDF_DFLTISR_RFOVRF) == MDF_DFLTISR_RFOVRF)
+  if ((interrupts & MDF_DFLTISR_RFOVRF) == MDF_DFLTISR_RFOVRF)
   {
     /* Clear reshape filter overrun flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_RFOVRF;
@@ -3107,7 +3107,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if clock absence detection occurs */
-  else if ((interrupts & MDF_DFLTISR_CKABF) == MDF_DFLTISR_CKABF)
+  if ((interrupts & MDF_DFLTISR_CKABF) == MDF_DFLTISR_CKABF)
   {
     /* Clear clock absence detection flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_CKABF;
@@ -3123,7 +3123,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if saturation occurs */
-  else if ((interrupts & MDF_DFLTISR_SATF) == MDF_DFLTISR_SATF)
+  if ((interrupts & MDF_DFLTISR_SATF) == MDF_DFLTISR_SATF)
   {
     /* Clear saturation flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SATF;
@@ -3139,7 +3139,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if short-circuit detection occurs */
-  else if ((interrupts & MDF_DFLTISR_SCDF) == MDF_DFLTISR_SCDF)
+  if ((interrupts & MDF_DFLTISR_SCDF) == MDF_DFLTISR_SCDF)
   {
     /* Clear short-circuit detection flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SCDF;
@@ -3155,7 +3155,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if out-off limit detection occurs */
-  else if ((interrupts & MDF_DFLTISR_OLDF) == MDF_DFLTISR_OLDF)
+  if ((interrupts & MDF_DFLTISR_OLDF) == MDF_DFLTISR_OLDF)
   {
     uint32_t threshold_info;
 
@@ -3187,7 +3187,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if sound activity detection occurs */
-  else if ((interrupts & MDF_DFLTISR_SDDETF) == MDF_DFLTISR_SDDETF)
+  if ((interrupts & MDF_DFLTISR_SDDETF) == MDF_DFLTISR_SDDETF)
   {
     /* Clear sound activity detection flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SDDETF;
@@ -3199,30 +3199,27 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
     HAL_MDF_SadCallback(hmdf);
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
-  else
+  /* Check if sound level ready occurs */
+  if ((interrupts & MDF_DFLTISR_SDLVLF) == MDF_DFLTISR_SDLVLF)
   {
-    /* Check if sound level ready occurs */
-    if ((interrupts & MDF_DFLTISR_SDLVLF) == MDF_DFLTISR_SDLVLF)
-    {
-      uint32_t sound_level;
-      uint32_t ambient_noise;
+    uint32_t sound_level;
+    uint32_t ambient_noise;
 
-      /* Get sound level */
-      sound_level = hmdf->Instance->SADSDLVR;
+    /* Get sound level */
+    sound_level = hmdf->Instance->SADSDLVR;
 
-      /* Get ambient noise */
-      ambient_noise = hmdf->Instance->SADANLVR;
+    /* Get ambient noise */
+    ambient_noise = hmdf->Instance->SADANLVR;
 
-      /* Clear sound level ready flag */
-      hmdf->Instance->DFLTISR |= MDF_DFLTISR_SDLVLF;
+    /* Clear sound level ready flag */
+    hmdf->Instance->DFLTISR |= MDF_DFLTISR_SDLVLF;
 
-      /* Call sound level callback */
+    /* Call sound level callback */
 #if (USE_HAL_MDF_REGISTER_CALLBACKS == 1)
-      hmdf->SndLvCallback(hmdf, sound_level, ambient_noise);
+    hmdf->SndLvCallback(hmdf, sound_level, ambient_noise);
 #else /* USE_HAL_MDF_REGISTER_CALLBACKS */
-      HAL_MDF_SndLvlCallback(hmdf, sound_level, ambient_noise);
+    HAL_MDF_SndLvlCallback(hmdf, sound_level, ambient_noise);
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
-    }
   }
 }
 

--- a/stm32cube/stm32n6xx/README
+++ b/stm32cube/stm32n6xx/README
@@ -101,4 +101,12 @@ Patch List:
     See also:
       https://github.com/zephyrproject-rtos/hal_stm32/pull/340
 
+   *Fix HAL_MDF_IRQHandler
+      HAL_MDF_IRQHandler handles IRQ flags in an if {} else if {} condition.
+      This causes interrupts to be handled once and only the first flag
+      encountered in the condition, while there can be several flags raised.
+     Impacted files:
+       drivers/src/stm32n6xx_hal_mdf.c
+     ST Internal Reference: HAL1-27843
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32n6xx/drivers/src/stm32n6xx_hal_mdf.c
+++ b/stm32cube/stm32n6xx/drivers/src/stm32n6xx_hal_mdf.c
@@ -3034,7 +3034,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if snapshot overrun occurs */
-  else if ((interrupts & MDF_DFLTISR_SSOVRF) == MDF_DFLTISR_SSOVRF)
+  if ((interrupts & MDF_DFLTISR_SSOVRF) == MDF_DFLTISR_SSOVRF)
   {
     /* Clear snapshot overrun flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SSOVRF;
@@ -3050,7 +3050,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if RXFIFO threshold occurs */
-  else if ((interrupts & MDF_DFLTISR_FTHF) == MDF_DFLTISR_FTHF)
+  if ((interrupts & MDF_DFLTISR_FTHF) == MDF_DFLTISR_FTHF)
   {
     /* Call acquisition complete callback */
 #if (USE_HAL_MDF_REGISTER_CALLBACKS == 1)
@@ -3066,7 +3066,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
     }
   }
   /* Check if snapshot data ready occurs */
-  else if ((interrupts & MDF_DFLTISR_SSDRF) == MDF_DFLTISR_SSDRF)
+  if ((interrupts & MDF_DFLTISR_SSDRF) == MDF_DFLTISR_SSDRF)
   {
     /* Clear snapshot data ready flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SSDRF;
@@ -3079,7 +3079,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if reshape filter overrun occurs */
-  else if ((interrupts & MDF_DFLTISR_RFOVRF) == MDF_DFLTISR_RFOVRF)
+  if ((interrupts & MDF_DFLTISR_RFOVRF) == MDF_DFLTISR_RFOVRF)
   {
     /* Clear reshape filter overrun flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_RFOVRF;
@@ -3095,7 +3095,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if clock absence detection occurs */
-  else if ((interrupts & MDF_DFLTISR_CKABF) == MDF_DFLTISR_CKABF)
+  if ((interrupts & MDF_DFLTISR_CKABF) == MDF_DFLTISR_CKABF)
   {
     /* Clear clock absence detection flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_CKABF;
@@ -3111,7 +3111,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if saturation occurs */
-  else if ((interrupts & MDF_DFLTISR_SATF) == MDF_DFLTISR_SATF)
+  if ((interrupts & MDF_DFLTISR_SATF) == MDF_DFLTISR_SATF)
   {
     /* Clear saturation flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SATF;
@@ -3127,7 +3127,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if short-circuit detection occurs */
-  else if ((interrupts & MDF_DFLTISR_SCDF) == MDF_DFLTISR_SCDF)
+  if ((interrupts & MDF_DFLTISR_SCDF) == MDF_DFLTISR_SCDF)
   {
     /* Clear short-circuit detection flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SCDF;
@@ -3143,7 +3143,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if out-off limit detection occurs */
-  else if ((interrupts & MDF_DFLTISR_OLDF) == MDF_DFLTISR_OLDF)
+  if ((interrupts & MDF_DFLTISR_OLDF) == MDF_DFLTISR_OLDF)
   {
     uint32_t threshold_info;
 
@@ -3175,7 +3175,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if sound activity detection occurs */
-  else if ((interrupts & MDF_DFLTISR_SDDETF) == MDF_DFLTISR_SDDETF)
+  if ((interrupts & MDF_DFLTISR_SDDETF) == MDF_DFLTISR_SDDETF)
   {
     /* Clear sound activity detection flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SDDETF;
@@ -3187,30 +3187,27 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
     HAL_MDF_SadCallback(hmdf);
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
-  else
+  /* Check if sound level ready occurs */
+  if ((interrupts & MDF_DFLTISR_SDLVLF) == MDF_DFLTISR_SDLVLF)
   {
-    /* Check if sound level ready occurs */
-    if ((interrupts & MDF_DFLTISR_SDLVLF) == MDF_DFLTISR_SDLVLF)
-    {
-      uint32_t sound_level;
-      uint32_t ambient_noise;
+    uint32_t sound_level;
+    uint32_t ambient_noise;
 
-      /* Get sound level */
-      sound_level = hmdf->Instance->SADSDLVR;
+    /* Get sound level */
+    sound_level = hmdf->Instance->SADSDLVR;
 
-      /* Get ambient noise */
-      ambient_noise = hmdf->Instance->SADANLVR;
+    /* Get ambient noise */
+    ambient_noise = hmdf->Instance->SADANLVR;
 
-      /* Clear sound level ready flag */
-      hmdf->Instance->DFLTISR |= MDF_DFLTISR_SDLVLF;
+    /* Clear sound level ready flag */
+    hmdf->Instance->DFLTISR |= MDF_DFLTISR_SDLVLF;
 
-      /* Call sound level callback */
+    /* Call sound level callback */
 #if (USE_HAL_MDF_REGISTER_CALLBACKS == 1)
-      hmdf->SndLvCallback(hmdf, sound_level, ambient_noise);
+    hmdf->SndLvCallback(hmdf, sound_level, ambient_noise);
 #else /* USE_HAL_MDF_REGISTER_CALLBACKS */
-      HAL_MDF_SndLvlCallback(hmdf, sound_level, ambient_noise);
+    HAL_MDF_SndLvlCallback(hmdf, sound_level, ambient_noise);
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
-    }
   }
 }
 

--- a/stm32cube/stm32u3xx/README
+++ b/stm32cube/stm32u3xx/README
@@ -48,4 +48,12 @@ Patch List:
     Impacted files:
     stm32cube/stm32u0xx/drivers/include/Legacy/stm32_hal_legacy.h
 
+   *Fix HAL_MDF_IRQHandler
+      HAL_MDF_IRQHandler handles IRQ flags in an if {} else if {} condition.
+      This causes interrupts to be handled once and only the first flag
+      encountered in the condition, while there can be several flags raised.
+     Impacted files:
+       drivers/src/stm32u3xx_hal_mdf.c
+     ST Internal Reference: HAL1-27843
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32u3xx/drivers/src/stm32u3xx_hal_mdf.c
+++ b/stm32cube/stm32u3xx/drivers/src/stm32u3xx_hal_mdf.c
@@ -1878,7 +1878,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if RXFIFO threshold occurs */
-  else if ((interrupts & MDF_DFLTISR_FTHF) == MDF_DFLTISR_FTHF)
+  if ((interrupts & MDF_DFLTISR_FTHF) == MDF_DFLTISR_FTHF)
   {
     /* Call acquisition complete callback */
 #if (USE_HAL_MDF_REGISTER_CALLBACKS == 1)
@@ -1894,7 +1894,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
     }
   }
   /* Check if reshape filter overrun occurs */
-  else if ((interrupts & MDF_DFLTISR_RFOVRF) == MDF_DFLTISR_RFOVRF)
+  if ((interrupts & MDF_DFLTISR_RFOVRF) == MDF_DFLTISR_RFOVRF)
   {
     /* Clear reshape filter overrun flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_RFOVRF;
@@ -1910,7 +1910,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if clock absence detection occurs */
-  else if ((interrupts & MDF_DFLTISR_CKABF) == MDF_DFLTISR_CKABF)
+  if ((interrupts & MDF_DFLTISR_CKABF) == MDF_DFLTISR_CKABF)
   {
     /* Clear clock absence detection flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_CKABF;
@@ -1926,7 +1926,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if saturation occurs */
-  else if ((interrupts & MDF_DFLTISR_SATF) == MDF_DFLTISR_SATF)
+  if ((interrupts & MDF_DFLTISR_SATF) == MDF_DFLTISR_SATF)
   {
     /* Clear saturation flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SATF;
@@ -1942,7 +1942,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if sound activity detection occurs */
-  else if ((interrupts & MDF_DFLTISR_SDDETF) == MDF_DFLTISR_SDDETF)
+  if ((interrupts & MDF_DFLTISR_SDDETF) == MDF_DFLTISR_SDDETF)
   {
     /* Clear sound activity detection flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SDDETF;
@@ -1954,30 +1954,27 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
     HAL_MDF_SadCallback(hmdf);
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
-  else
+  /* Check if sound level ready occurs */
+  if ((interrupts & MDF_DFLTISR_SDLVLF) == MDF_DFLTISR_SDLVLF)
   {
-    /* Check if sound level ready occurs */
-    if ((interrupts & MDF_DFLTISR_SDLVLF) == MDF_DFLTISR_SDLVLF)
-    {
-      uint32_t sound_level;
-      uint32_t ambient_noise;
+    uint32_t sound_level;
+    uint32_t ambient_noise;
 
-      /* Get sound level */
-      sound_level = hmdf->Instance->SADSDLVR;
+    /* Get sound level */
+    sound_level = hmdf->Instance->SADSDLVR;
 
-      /* Get ambient noise */
-      ambient_noise = hmdf->Instance->SADANLVR;
+    /* Get ambient noise */
+    ambient_noise = hmdf->Instance->SADANLVR;
 
-      /* Clear sound level ready flag */
-      hmdf->Instance->DFLTISR |= MDF_DFLTISR_SDLVLF;
+    /* Clear sound level ready flag */
+    hmdf->Instance->DFLTISR |= MDF_DFLTISR_SDLVLF;
 
-      /* Call sound level callback */
+    /* Call sound level callback */
 #if (USE_HAL_MDF_REGISTER_CALLBACKS == 1)
-      hmdf->SndLvCallback(hmdf, sound_level, ambient_noise);
+    hmdf->SndLvCallback(hmdf, sound_level, ambient_noise);
 #else /* USE_HAL_MDF_REGISTER_CALLBACKS */
-      HAL_MDF_SndLvlCallback(hmdf, sound_level, ambient_noise);
+    HAL_MDF_SndLvlCallback(hmdf, sound_level, ambient_noise);
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
-    }
   }
 }
 

--- a/stm32cube/stm32u5xx/README
+++ b/stm32cube/stm32u5xx/README
@@ -72,4 +72,12 @@ Patch List:
      See also:
       https://github.com/zephyrproject-rtos/hal_stm32/pull/355
 
+   *Fix HAL_MDF_IRQHandler
+      HAL_MDF_IRQHandler handles IRQ flags in an if {} else if {} condition.
+      This causes interrupts to be handled once and only the first flag
+      encountered in the condition, while there can be several flags raised.
+     Impacted files:
+       drivers/src/stm32u5xx_hal_mdf.c
+     ST Internal Reference: HAL1-27843
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32u5xx/drivers/src/stm32u5xx_hal_mdf.c
+++ b/stm32cube/stm32u5xx/drivers/src/stm32u5xx_hal_mdf.c
@@ -3038,7 +3038,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if snapshot overrun occurs */
-  else if ((interrupts & MDF_DFLTISR_SSOVRF) == MDF_DFLTISR_SSOVRF)
+  if ((interrupts & MDF_DFLTISR_SSOVRF) == MDF_DFLTISR_SSOVRF)
   {
     /* Clear snapshot overrun flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SSOVRF;
@@ -3054,7 +3054,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if RXFIFO threshold occurs */
-  else if ((interrupts & MDF_DFLTISR_FTHF) == MDF_DFLTISR_FTHF)
+  if ((interrupts & MDF_DFLTISR_FTHF) == MDF_DFLTISR_FTHF)
   {
     /* Call acquisition complete callback */
 #if (USE_HAL_MDF_REGISTER_CALLBACKS == 1)
@@ -3070,7 +3070,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
     }
   }
   /* Check if snapshot data ready occurs */
-  else if ((interrupts & MDF_DFLTISR_SSDRF) == MDF_DFLTISR_SSDRF)
+  if ((interrupts & MDF_DFLTISR_SSDRF) == MDF_DFLTISR_SSDRF)
   {
     /* Clear snapshot data ready flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SSDRF;
@@ -3083,7 +3083,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if reshape filter overrun occurs */
-  else if ((interrupts & MDF_DFLTISR_RFOVRF) == MDF_DFLTISR_RFOVRF)
+  if ((interrupts & MDF_DFLTISR_RFOVRF) == MDF_DFLTISR_RFOVRF)
   {
     /* Clear reshape filter overrun flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_RFOVRF;
@@ -3099,7 +3099,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if clock absence detection occurs */
-  else if ((interrupts & MDF_DFLTISR_CKABF) == MDF_DFLTISR_CKABF)
+  if ((interrupts & MDF_DFLTISR_CKABF) == MDF_DFLTISR_CKABF)
   {
     /* Clear clock absence detection flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_CKABF;
@@ -3115,7 +3115,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if saturation occurs */
-  else if ((interrupts & MDF_DFLTISR_SATF) == MDF_DFLTISR_SATF)
+  if ((interrupts & MDF_DFLTISR_SATF) == MDF_DFLTISR_SATF)
   {
     /* Clear saturation flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SATF;
@@ -3131,7 +3131,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if short-circuit detection occurs */
-  else if ((interrupts & MDF_DFLTISR_SCDF) == MDF_DFLTISR_SCDF)
+  if ((interrupts & MDF_DFLTISR_SCDF) == MDF_DFLTISR_SCDF)
   {
     /* Clear short-circuit detection flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SCDF;
@@ -3147,7 +3147,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if out-off limit detection occurs */
-  else if ((interrupts & MDF_DFLTISR_OLDF) == MDF_DFLTISR_OLDF)
+  if ((interrupts & MDF_DFLTISR_OLDF) == MDF_DFLTISR_OLDF)
   {
     uint32_t threshold_info;
 
@@ -3179,7 +3179,7 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
   /* Check if sound activity detection occurs */
-  else if ((interrupts & MDF_DFLTISR_SDDETF) == MDF_DFLTISR_SDDETF)
+  if ((interrupts & MDF_DFLTISR_SDDETF) == MDF_DFLTISR_SDDETF)
   {
     /* Clear sound activity detection flag */
     hmdf->Instance->DFLTISR |= MDF_DFLTISR_SDDETF;
@@ -3191,30 +3191,27 @@ void HAL_MDF_IRQHandler(MDF_HandleTypeDef *hmdf)
     HAL_MDF_SadCallback(hmdf);
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
   }
-  else
+  /* Check if sound level ready occurs */
+  if ((interrupts & MDF_DFLTISR_SDLVLF) == MDF_DFLTISR_SDLVLF)
   {
-    /* Check if sound level ready occurs */
-    if ((interrupts & MDF_DFLTISR_SDLVLF) == MDF_DFLTISR_SDLVLF)
-    {
-      uint32_t sound_level;
-      uint32_t ambient_noise;
+    uint32_t sound_level;
+    uint32_t ambient_noise;
 
-      /* Get sound level */
-      sound_level = hmdf->Instance->SADSDLVR;
+    /* Get sound level */
+    sound_level = hmdf->Instance->SADSDLVR;
 
-      /* Get ambient noise */
-      ambient_noise = hmdf->Instance->SADANLVR;
+    /* Get ambient noise */
+    ambient_noise = hmdf->Instance->SADANLVR;
 
-      /* Clear sound level ready flag */
-      hmdf->Instance->DFLTISR |= MDF_DFLTISR_SDLVLF;
+    /* Clear sound level ready flag */
+    hmdf->Instance->DFLTISR |= MDF_DFLTISR_SDLVLF;
 
-      /* Call sound level callback */
+    /* Call sound level callback */
 #if (USE_HAL_MDF_REGISTER_CALLBACKS == 1)
-      hmdf->SndLvCallback(hmdf, sound_level, ambient_noise);
+    hmdf->SndLvCallback(hmdf, sound_level, ambient_noise);
 #else /* USE_HAL_MDF_REGISTER_CALLBACKS */
-      HAL_MDF_SndLvlCallback(hmdf, sound_level, ambient_noise);
+    HAL_MDF_SndLvlCallback(hmdf, sound_level, ambient_noise);
 #endif /* USE_HAL_MDF_REGISTER_CALLBACKS */
-    }
   }
 }
 


### PR DESCRIPTION
HAL_MDF_IRQHandler handles IRQ flags in an `if {} else if {}` condition. This causes interrupts to be handled once and only the first flag encountered in the condition, while there can be several flags raised.

Fix this issue and add a patch entry.

Internal bug report number is #HAL1-27843