### PR TITLE
hal: stm32: add REUSE.toml and LICENSES/ for SPDX 3.0 SBOM compliance

### DIFF
--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,194 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship made available under
+   the License, as indicated by a copyright notice that is included in
+   or attached to the work (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean, as to the Licensor, the original version of
+   the Work and any additions or modifications to that Work or Derivative
+   Works of that Work that are intentionally submitted to the Licensor for
+   inclusion in the Work by the copyright owner or by an individual or
+   Legal Entity authorized to submit on behalf of the copyright owner. For
+   the purposes of this definition, "submitted" means any form of
+   electronic, verbal, or written communication sent to the Licensor or
+   its representatives, including but not limited to communication on
+   electronic mailing lists, source code control systems, and issue
+   tracking systems that are managed by, or on behalf of, the Licensor for
+   the purpose of discussing and improving the Work, but excluding
+   communication that is conspicuously marked or otherwise designated in
+   writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any Legal Entity on behalf of
+   whom a Contribution has been received by the Licensor and subsequently
+   incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a cross-claim
+   or counterclaim in a lawsuit) alleging that the Work or a Contribution
+   incorporated within the Work constitutes direct or contributory patent
+   infringement, then any patent licenses granted to You under this License
+   for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work
+   or Derivative Works thereof in any medium, with or without modifications,
+   and in Source or Object form, provided that You meet the following
+   conditions:
+
+   (a) You must give any other recipients of the Work or Derivative Works
+       a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works that
+       You distribute, all copyright, patent, trademark, and attribution
+       notices from the Source form of the Work, excluding those notices
+       that do not pertain to any part of the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, You must include a readable copy of the attribution
+       notices contained within such NOTICE file, in at least one of the
+       following places: within a NOTICE text file distributed as part of
+       the Derivative Works; within the Source form or documentation, if
+       provided along with the Derivative Works; or, within a display
+       generated by the Derivative Works, if and wherever such third-party
+       notices normally appear. The contents of the NOTICE file are for
+       informational purposes only and do not modify the License. You may
+       add Your own attribution notices within Derivative Works that You
+       distribute, alongside or as an addendum to the NOTICE text from the
+       Work, provided that such additional attribution notices cannot be
+       construed as modifying the License.
+
+   You may add Your own license statement for Your modifications and
+   may provide additional grant of rights to use, reproduce, modify, and
+   distribute such modifications, provided that your use, reproduction,
+   modification, and distribution of the Work otherwise complies with the
+   conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work by
+   You to the Licensor shall be under the terms and conditions of this
+   License, without any additional terms or conditions. Notwithstanding
+   the above, nothing herein shall supersede or modify the terms of any
+   separate license agreement you may have executed with Licensor regarding
+   such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or exemplary damages of any character arising as a result
+   of this License or out of the use or inability to use the Work
+   (including but not limited to damages for loss of goodwill, work
+   stoppage, computer failure or malfunction, or all other commercial
+   damages or losses), even if such Contributor has been advised of the
+   possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer, and
+   charge a fee for, acceptance of support, warranty, indemnity, or other
+   liability obligations and/or rights consistent with this License.
+   However, in accepting such obligations, You may offer such support only
+   on Your own behalf and on Your sole responsibility, not on behalf of any
+   other Contributor, and only if You agree to indemnify, defend, and hold
+   each Contributor harmless for any liability incurred by, or claims
+   asserted against, such Contributor by reason of your accepting any such
+   warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!) The text should be enclosed in the appropriate
+   comment syntax for the file format in use. We also recommend that
+   a file or class name and a description of its purpose be included on
+   the same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) STMicroelectronics
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSES/LicenseRef-ST-SLA0044.txt
+++ b/LICENSES/LicenseRef-ST-SLA0044.txt
@@ -1,0 +1,80 @@
+SLA0044 Rev5/February 2018
+
+Software license agreement
+
+ULTIMATE LIBERTY SOFTWARE LICENSE AGREEMENT
+
+BY INSTALLING, COPYING, DOWNLOADING, ACCESSING OR OTHERWISE USING THIS SOFTWARE
+OR ANY PART THEREOF (AND THE RELATED DOCUMENTATION) FROM STMICROELECTRONICS
+INTERNATIONAL N.V, SWISS BRANCH AND/OR ITS AFFILIATED COMPANIES
+(STMICROELECTRONICS), THE RECIPIENT, ON BEHALF OF HIMSELF OR HERSELF, OR ON
+BEHALF OF ANY ENTITY BY WHICH SUCH RECIPIENT IS EMPLOYED AND/OR ENGAGED AGREES
+TO BE BOUND BY THIS SOFTWARE LICENSE AGREEMENT.
+
+Under STMicroelectronics' intellectual property rights, the redistribution,
+reproduction and use in source and binary forms of the software or any part
+thereof, with or without modification, are permitted provided that the following
+conditions are met:
+
+1. Redistribution of source code (modified or not) must retain any copyright
+notice, this list of conditions and the disclaimer set forth below as items 10
+and 11.
+
+2. Redistributions in binary form, except as embedded into microcontroller or
+microprocessor device manufactured by or for STMicroelectronics or a software
+update for such device, must reproduce any copyright notice provided with the
+binary code, this list of conditions, and the disclaimer set forth below as
+items 10 and 11, in documentation and/or other materials provided with the
+distribution.
+
+3. Neither the name of STMicroelectronics nor the names of other contributors to
+this software may be used to endorse or promote products derived from this
+software or part thereof without specific written permission.
+
+4. This software or any part thereof, including modifications and/or derivative
+works of this software, must be used and execute solely and exclusively on or in
+combination with a microcontroller or microprocessor device manufactured by or
+for STMicroelectronics.
+
+5. No use, reproduction or redistribution of this software partially or totally
+may be done in any manner that would subject this software to any Open Source
+Terms. "Open Source Terms" shall mean any open source license which requires as
+part of distribution of software that the source code of such software is
+distributed therewith or otherwise made available, or open source license that
+substantially complies with the Open Source definition specified at
+www.opensource.org and any other comparable open source license such as for
+example GNU General Public License (GPL), Eclipse Public License (EPL), Apache
+Software License, BSD license or MIT license.
+
+6. STMicroelectronics has no obligation to provide any maintenance, support or
+updates for the software.
+
+7. The software is and will remain the exclusive property of STMicroelectronics
+and its licensors. The recipient will not take any action that jeopardizes
+STMicroelectronics and its licensors' proprietary rights or acquire any rights
+in the software, except the limited rights specified hereunder.
+
+8. The recipient shall comply with all applicable laws and regulations affecting
+the use of the software or any part thereof including any applicable export
+control law or regulation.
+
+9. Redistribution and use of this software or any part thereof other than as
+permitted under this license is void and will automatically terminate your
+rights under this license.
+
+10. THIS SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY RIGHTS, WHICH ARE
+DISCLAIMED TO THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT SHALL
+STMICROELECTRONICS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+11. EXCEPT AS EXPRESSLY PERMITTED HEREUNDER, NO LICENSE OR OTHER RIGHTS, WHETHER
+EXPRESS OR IMPLIED, ARE GRANTED UNDER ANY PATENT OR OTHER INTELLECTUAL PROPERTY
+RIGHTS OF STMICROELECTRONICS OR ANY THIRD PARTY.

--- a/LICENSES/LicenseRef-ST-SLA0044.txt
+++ b/LICENSES/LicenseRef-ST-SLA0044.txt
@@ -1,80 +1,85 @@
-SLA0044 Rev5/February 2018
-
-Software license agreement
+SLA0044 Rev6/October 2025
 
 ULTIMATE LIBERTY SOFTWARE LICENSE AGREEMENT
 
-BY INSTALLING, COPYING, DOWNLOADING, ACCESSING OR OTHERWISE USING THIS SOFTWARE
-OR ANY PART THEREOF (AND THE RELATED DOCUMENTATION) FROM STMICROELECTRONICS
-INTERNATIONAL N.V, SWISS BRANCH AND/OR ITS AFFILIATED COMPANIES
-(STMICROELECTRONICS), THE RECIPIENT, ON BEHALF OF HIMSELF OR HERSELF, OR ON
-BEHALF OF ANY ENTITY BY WHICH SUCH RECIPIENT IS EMPLOYED AND/OR ENGAGED AGREES
-TO BE BOUND BY THIS SOFTWARE LICENSE AGREEMENT.
+BY CLICKING ON THE "I ACCEPT" BUTTON OR BY UNZIPPING, INSTALLING, COPYING,
+DOWNLOADING, ACCESSING OR OTHERWISE USING THIS SOFTWARE OR ANY PART THEREOF,
+INCLUDING ANY RELATED DOCUMENTATION (collectively the "SOFTWARE") FROM
+STMICROELECTRONICS INTERNATIONAL N.V, SWISS BRANCH AND/OR ITS AFFILIATED
+COMPANIES (collectively "STMICROELECTRONICS"), YOU (hereinafter referred also
+to as "THE RECIPIENT"), ON BEHALF OF YOURSELF, OR ON BEHALF OF ANY ENTITY BY
+WHICH YOU ARE EMPLOYED AND/OR ENGAGED, AGREE TO BE BOUND BY THIS AGREEMENT.
 
-Under STMicroelectronics' intellectual property rights, the redistribution,
-reproduction and use in source and binary forms of the software or any part
+Under STMICROELECTRONICS' intellectual property rights, the redistribution,
+reproduction and use in source and binary forms of the SOFTWARE or any part
 thereof, with or without modification, are permitted provided that the following
 conditions are met:
 
 1. Redistribution of source code (modified or not) must retain any copyright
-notice, this list of conditions and the disclaimer set forth below as items 10
-and 11.
+   notice accompanying the SOFTWARE, this list of conditions and the disclaimer
+   below.
 
-2. Redistributions in binary form, except as embedded into microcontroller or
-microprocessor device manufactured by or for STMicroelectronics or a software
-update for such device, must reproduce any copyright notice provided with the
-binary code, this list of conditions, and the disclaimer set forth below as
-items 10 and 11, in documentation and/or other materials provided with the
-distribution.
+2. Redistributions in binary form, except as embedded into a processing unit
+   device manufactured by or for STMicroelectronics or a software update for
+   any such device, must reproduce the accompanying copyright notice, this list
+   of conditions, and the below disclaimer in capital type, in the documentation
+   and/or other materials provided with the distribution.
 
-3. Neither the name of STMicroelectronics nor the names of other contributors to
-this software may be used to endorse or promote products derived from this
-software or part thereof without specific written permission.
+3. Neither the name of STMicroelectronics nor the names of other contributors
+   to the SOFTWARE may be used to endorse or promote products derived from the
+   SOFTWARE or part thereof without specific written permission.
 
-4. This software or any part thereof, including modifications and/or derivative
-works of this software, must be used and execute solely and exclusively on or in
-combination with a microcontroller or microprocessor device manufactured by or
-for STMicroelectronics.
+4. The SOFTWARE or any part thereof, including modifications and/or derivative
+   works of the SOFTWARE, must be used and execute solely and exclusively on or
+   in combination with a processing unit device manufactured by or for
+   STMicroelectronics.
 
-5. No use, reproduction or redistribution of this software partially or totally
-may be done in any manner that would subject this software to any Open Source
-Terms. "Open Source Terms" shall mean any open source license which requires as
-part of distribution of software that the source code of such software is
-distributed therewith or otherwise made available, or open source license that
-substantially complies with the Open Source definition specified at
-www.opensource.org and any other comparable open source license such as for
-example GNU General Public License (GPL), Eclipse Public License (EPL), Apache
-Software License, BSD license or MIT license.
+5. No use, reproduction or redistribution of the SOFTWARE partially or totally
+   may be done in any manner that would subject the SOFTWARE to any Open Source
+   Terms. "Open Source Terms" shall mean any open source license which requires
+   as part of distribution of software that the source code of such software is
+   distributed therewith or otherwise made available, or open source license
+   that substantially complies with the Open Source definition specified at
+   www.opensource.org and any other comparable open source license such as for
+   example GNU General Public License (GPL), Eclipse Public License (EPL),
+   Apache Software License, BSD license or MIT license.
 
 6. STMicroelectronics has no obligation to provide any maintenance, support or
-updates for the software.
+   updates for the SOFTWARE.
 
-7. The software is and will remain the exclusive property of STMicroelectronics
-and its licensors. The recipient will not take any action that jeopardizes
-STMicroelectronics and its licensors' proprietary rights or acquire any rights
-in the software, except the limited rights specified hereunder.
+7. The SOFTWARE is and will remain the exclusive property of STMicroelectronics
+   and its licensors. The RECIPIENT will not take any action that jeopardizes
+   STMicroelectronics and its licensors' proprietary rights or acquire any
+   rights in the SOFTWARE, except the limited rights specified hereunder.
 
-8. The recipient shall comply with all applicable laws and regulations affecting
-the use of the software or any part thereof including any applicable export
-control law or regulation.
+8. The RECIPIENT shall comply with all applicable laws and regulations affecting
+   the use of the SOFTWARE or any part thereof including any applicable export
+   control law or regulation.
 
-9. Redistribution and use of this software or any part thereof other than as
-permitted under this license is void and will automatically terminate your
-rights under this license.
+9. Redistribution and use of the SOFTWARE or any part thereof other than as
+   permitted under this AGREEMENT is void and will automatically terminate
+   RECIPIENT's rights under this AGREEMENT.
 
-10. THIS SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+10. The RECIPIENT shall be solely liable to determine and verify that the
+    SOFTWARE is fit for the RECIPIENT intended use, environment or application
+    and comply with all regulatory, safety and security related requirements
+    concerning any use.
+
+DISCLAIMER:
+
+THE SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY RIGHTS, WHICH ARE
-DISCLAIMED TO THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT SHALL
-STMICROELECTRONICS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
-OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
-ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY RIGHTS, ARE DISCLAIMED TO
+THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT SHALL STMICROELECTRONICS OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THE SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
 
-11. EXCEPT AS EXPRESSLY PERMITTED HEREUNDER, NO LICENSE OR OTHER RIGHTS, WHETHER
-EXPRESS OR IMPLIED, ARE GRANTED UNDER ANY PATENT OR OTHER INTELLECTUAL PROPERTY
-RIGHTS OF STMICROELECTRONICS OR ANY THIRD PARTY.
+EXCEPT AS EXPRESSLY PERMITTED HEREUNDER, NO LICENSE OR OTHER RIGHTS, WHETHER
+EXPRESS OR IMPLIED, ARE GRANTED UNDER ANY PATENT OR OTHER INTELLECTUAL
+PROPERTY RIGHTS OF STMICROELECTRONICS OR ANY THIRD PARTY.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) STMicroelectronics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+#
+# REUSE.toml — REUSE Specification 3.3 bulk annotations for hal_stm32
+# https://reuse.software/spec-3.3/
+#
+# This file provides SPDX license and copyright metadata for files that do not
+# carry in-file SPDX-License-Identifier or SPDX-FileCopyrightText tags.
+# In-file tags always take
+# precedence over entries below (REUSE spec §3.3).
+#
+# Licenses referenced here must have their full text under LICENSES/.
+
+version = 1
+
+# ---------------------------------------------------------------------------
+# Zephyr integration files (CMakeLists, module metadata, scripts, DTS, …)
+# ---------------------------------------------------------------------------
+[[annotations]]
+path = [
+  "CMakeLists.txt",
+  "README.rst",
+  "zephyr/module.yml",
+  "scripts/**",
+  "dts/**",
+  "lib/**/CMakeLists.txt",
+  "stm32cube/**/CMakeLists.txt",
+  "stm32cube/series_list.cmake",
+]
+SPDX-FileCopyrightText = "Copyright The Zephyr Project Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+# ---------------------------------------------------------------------------
+# STM32Cube HAL1 SOC headers and startup files (Apache-2.0)
+# ---------------------------------------------------------------------------
+[[annotations]]
+path = "stm32cube/*/soc/**"
+SPDX-FileCopyrightText = "Copyright (c) STMicroelectronics"
+SPDX-License-Identifier = "Apache-2.0"
+
+# ---------------------------------------------------------------------------
+# STM32Cube HAL/LL driver files and HAL2 dfp (BSD-3-Clause)
+# ---------------------------------------------------------------------------
+[[annotations]]
+path = "stm32cube/*/drivers/**"
+SPDX-FileCopyrightText = "Copyright (c) STMicroelectronics"
+SPDX-License-Identifier = "BSD-3-Clause"
+
+# HAL2-based series: dfp
+[[annotations]]
+path = "stm32cube/*/dfp/**"
+SPDX-FileCopyrightText = "Copyright (c) STMicroelectronics"
+SPDX-License-Identifier = "BSD-3-Clause"
+
+# Common LL headers shared across series
+[[annotations]]
+path = "stm32cube/common_ll/**"
+SPDX-FileCopyrightText = "Copyright (c) STMicroelectronics"
+SPDX-License-Identifier = "Apache-2.0"
+
+# ---------------------------------------------------------------------------
+# Library components under lib/ (BSD-3-Clause, except ll_cmd_lib)
+# ---------------------------------------------------------------------------
+[[annotations]]
+path = [
+  "lib/stm32wb/**",
+  "lib/stm32wba/**",
+  "lib/stm32wb0/**",
+  "lib/vc8000nanoe/**",
+]
+SPDX-FileCopyrightText = "Copyright (c) STMicroelectronics"
+SPDX-License-Identifier = "BSD-3-Clause"
+
+# MIT exception: WBA link-layer command library
+[[annotations]]
+path = "lib/stm32wba/STM32_WPAN/link_layer/ll_cmd_lib/**"
+SPDX-FileCopyrightText = "Copyright (c) STMicroelectronics"
+SPDX-License-Identifier = "MIT"
+
+# ---------------------------------------------------------------------------
+# Binary blobs — ST proprietary SLA0044
+# ---------------------------------------------------------------------------
+[[annotations]]
+path = "zephyr/blobs/**"
+SPDX-FileCopyrightText = "Copyright (c) STMicroelectronics"
+SPDX-License-Identifier = "LicenseRef-ST-SLA0044"

--- a/zephyr/blobs/stm32wb0/lib/license.md
+++ b/zephyr/blobs/stm32wb0/lib/license.md
@@ -1,80 +1,87 @@
-SLA0044 Rev5/February 2018
+SLA0044 Rev6/October 2025
 
 ## Software license agreement
 
 ### __ULTIMATE LIBERTY SOFTWARE LICENSE AGREEMENT__
 
-BY INSTALLING, COPYING, DOWNLOADING, ACCESSING OR OTHERWISE USING THIS SOFTWARE
-OR ANY PART THEREOF (AND THE RELATED DOCUMENTATION) FROM STMICROELECTRONICS
-INTERNATIONAL N.V, SWISS BRANCH AND/OR ITS AFFILIATED COMPANIES
-(STMICROELECTRONICS), THE RECIPIENT, ON BEHALF OF HIMSELF OR HERSELF, OR ON
-BEHALF OF ANY ENTITY BY WHICH SUCH RECIPIENT IS EMPLOYED AND/OR ENGAGED AGREES
-TO BE BOUND BY THIS SOFTWARE LICENSE AGREEMENT.
+BY CLICKING ON THE "I ACCEPT" BUTTON OR BY UNZIPPING, INSTALLING, COPYING,
+DOWNLOADING, ACCESSING OR OTHERWISE USING THIS SOFTWARE OR ANY PART THEREOF,
+INCLUDING ANY RELATED DOCUMENTATION (collectively the "SOFTWARE") FROM
+STMICROELECTRONICS INTERNATIONAL N.V, SWISS BRANCH AND/OR ITS AFFILIATED
+COMPANIES (collectively "STMICROELECTRONICS"), YOU (hereinafter referred also
+to as "THE RECIPIENT"), ON BEHALF OF YOURSELF, OR ON BEHALF OF ANY ENTITY BY
+WHICH YOU ARE EMPLOYED AND/OR ENGAGED, AGREE TO BE BOUND BY THIS AGREEMENT.
 
-Under STMicroelectronics’ intellectual property rights, the redistribution,
-reproduction and use in source and binary forms of the software or any part
+Under STMICROELECTRONICS' intellectual property rights, the redistribution,
+reproduction and use in source and binary forms of the SOFTWARE or any part
 thereof, with or without modification, are permitted provided that the following
 conditions are met:
 
 1. Redistribution of source code (modified or not) must retain any copyright
-notice, this list of conditions and the disclaimer set forth below as items 10
-and 11.
+   notice accompanying the SOFTWARE, this list of conditions and the disclaimer
+   below.
 
-2. Redistributions in binary form, except as embedded into microcontroller or
-microprocessor device manufactured by or for STMicroelectronics or a software
-update for such device, must reproduce any copyright notice provided with the
-binary code, this list of conditions, and the disclaimer set forth below as
-items 10 and 11, in documentation and/or other materials provided with the
-distribution.
+2. Redistributions in binary form, except as embedded into a processing unit
+   device manufactured by or for STMicroelectronics or a software update for
+   any such device, must reproduce the accompanying copyright notice, this list
+   of conditions, and the below disclaimer in capital type, in the documentation
+   and/or other materials provided with the distribution.
 
-3. Neither the name of STMicroelectronics nor the names of other contributors to
-this software may be used to endorse or promote products derived from this
-software or part thereof without specific written permission.
+3. Neither the name of STMicroelectronics nor the names of other contributors
+   to the SOFTWARE may be used to endorse or promote products derived from the
+   SOFTWARE or part thereof without specific written permission.
 
-4. This software or any part thereof, including modifications and/or derivative
-works of this software, must be used and execute solely and exclusively on or in
-combination with a microcontroller or microprocessor device manufactured by or
-for STMicroelectronics.
+4. The SOFTWARE or any part thereof, including modifications and/or derivative
+   works of the SOFTWARE, must be used and execute solely and exclusively on or
+   in combination with a processing unit device manufactured by or for
+   STMicroelectronics.
 
-5. No use, reproduction or redistribution of this software partially or totally
-may be done in any manner that would subject this software to any Open Source
-Terms. “Open Source Terms” shall mean any open source license which requires as
-part of distribution of software that the source code of such software is
-distributed therewith or otherwise made available, or open source license that
-substantially complies with the Open Source definition specified at
-www.opensource.org and any other comparable open source license such as for
-example GNU General Public License (GPL), Eclipse Public License (EPL), Apache
-Software License, BSD license or MIT license.
+5. No use, reproduction or redistribution of the SOFTWARE partially or totally
+   may be done in any manner that would subject the SOFTWARE to any Open Source
+   Terms. "Open Source Terms" shall mean any open source license which requires
+   as part of distribution of software that the source code of such software is
+   distributed therewith or otherwise made available, or open source license
+   that substantially complies with the Open Source definition specified at
+   www.opensource.org and any other comparable open source license such as for
+   example GNU General Public License (GPL), Eclipse Public License (EPL),
+   Apache Software License, BSD license or MIT license.
 
 6. STMicroelectronics has no obligation to provide any maintenance, support or
-updates for the software.
+   updates for the SOFTWARE.
 
-7. The software is and will remain the exclusive property of STMicroelectronics
-and its licensors. The recipient will not take any action that jeopardizes
-STMicroelectronics and its licensors' proprietary rights or acquire any rights
-in the software, except the limited rights specified hereunder.
+7. The SOFTWARE is and will remain the exclusive property of STMicroelectronics
+   and its licensors. The RECIPIENT will not take any action that jeopardizes
+   STMicroelectronics and its licensors' proprietary rights or acquire any
+   rights in the SOFTWARE, except the limited rights specified hereunder.
 
-8. The recipient shall comply with all applicable laws and regulations affecting
-the use of the software or any part thereof including any applicable export
-control law or regulation.
+8. The RECIPIENT shall comply with all applicable laws and regulations affecting
+   the use of the SOFTWARE or any part thereof including any applicable export
+   control law or regulation.
 
-9. Redistribution and use of this software or any part thereof other than as
-permitted under this license is void and will automatically terminate your
-rights under this license.
+9. Redistribution and use of the SOFTWARE or any part thereof other than as
+   permitted under this AGREEMENT is void and will automatically terminate
+   RECIPIENT's rights under this AGREEMENT.
 
-10. THIS SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+10. The RECIPIENT shall be solely liable to determine and verify that the
+    SOFTWARE is fit for the RECIPIENT intended use, environment or application
+    and comply with all regulatory, safety and security related requirements
+    concerning any use.
+
+DISCLAIMER:
+
+THE SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY RIGHTS, WHICH ARE
-DISCLAIMED TO THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT SHALL
-STMICROELECTRONICS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
-OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
-ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY RIGHTS, ARE DISCLAIMED TO
+THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT SHALL STMICROELECTRONICS OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THE SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
 
-11. EXCEPT AS EXPRESSLY PERMITTED HEREUNDER, NO LICENSE OR OTHER RIGHTS, WHETHER
-EXPRESS OR IMPLIED, ARE GRANTED UNDER ANY PATENT OR OTHER INTELLECTUAL PROPERTY
-RIGHTS OF STMICROELECTRONICS OR ANY THIRD PARTY.
+EXCEPT AS EXPRESSLY PERMITTED HEREUNDER, NO LICENSE OR OTHER RIGHTS, WHETHER
+EXPRESS OR IMPLIED, ARE GRANTED UNDER ANY PATENT OR OTHER INTELLECTUAL
+PROPERTY RIGHTS OF STMICROELECTRONICS OR ANY THIRD PARTY.

--- a/zephyr/blobs/stm32wba/lib/license.md
+++ b/zephyr/blobs/stm32wba/lib/license.md
@@ -1,80 +1,87 @@
-SLA0044 Rev5/February 2018
+SLA0044 Rev6/October 2025
 
 ## Software license agreement
 
 ### __ULTIMATE LIBERTY SOFTWARE LICENSE AGREEMENT__
 
-BY INSTALLING, COPYING, DOWNLOADING, ACCESSING OR OTHERWISE USING THIS SOFTWARE
-OR ANY PART THEREOF (AND THE RELATED DOCUMENTATION) FROM STMICROELECTRONICS
-INTERNATIONAL N.V, SWISS BRANCH AND/OR ITS AFFILIATED COMPANIES
-(STMICROELECTRONICS), THE RECIPIENT, ON BEHALF OF HIMSELF OR HERSELF, OR ON
-BEHALF OF ANY ENTITY BY WHICH SUCH RECIPIENT IS EMPLOYED AND/OR ENGAGED AGREES
-TO BE BOUND BY THIS SOFTWARE LICENSE AGREEMENT.
+BY CLICKING ON THE "I ACCEPT" BUTTON OR BY UNZIPPING, INSTALLING, COPYING,
+DOWNLOADING, ACCESSING OR OTHERWISE USING THIS SOFTWARE OR ANY PART THEREOF,
+INCLUDING ANY RELATED DOCUMENTATION (collectively the "SOFTWARE") FROM
+STMICROELECTRONICS INTERNATIONAL N.V, SWISS BRANCH AND/OR ITS AFFILIATED
+COMPANIES (collectively "STMICROELECTRONICS"), YOU (hereinafter referred also
+to as "THE RECIPIENT"), ON BEHALF OF YOURSELF, OR ON BEHALF OF ANY ENTITY BY
+WHICH YOU ARE EMPLOYED AND/OR ENGAGED, AGREE TO BE BOUND BY THIS AGREEMENT.
 
-Under STMicroelectronics’ intellectual property rights, the redistribution,
-reproduction and use in source and binary forms of the software or any part
+Under STMICROELECTRONICS' intellectual property rights, the redistribution,
+reproduction and use in source and binary forms of the SOFTWARE or any part
 thereof, with or without modification, are permitted provided that the following
 conditions are met:
 
 1. Redistribution of source code (modified or not) must retain any copyright
-notice, this list of conditions and the disclaimer set forth below as items 10
-and 11.
+   notice accompanying the SOFTWARE, this list of conditions and the disclaimer
+   below.
 
-2. Redistributions in binary form, except as embedded into microcontroller or
-microprocessor device manufactured by or for STMicroelectronics or a software
-update for such device, must reproduce any copyright notice provided with the
-binary code, this list of conditions, and the disclaimer set forth below as
-items 10 and 11, in documentation and/or other materials provided with the
-distribution.
+2. Redistributions in binary form, except as embedded into a processing unit
+   device manufactured by or for STMicroelectronics or a software update for
+   any such device, must reproduce the accompanying copyright notice, this list
+   of conditions, and the below disclaimer in capital type, in the documentation
+   and/or other materials provided with the distribution.
 
-3. Neither the name of STMicroelectronics nor the names of other contributors to
-this software may be used to endorse or promote products derived from this
-software or part thereof without specific written permission.
+3. Neither the name of STMicroelectronics nor the names of other contributors
+   to the SOFTWARE may be used to endorse or promote products derived from the
+   SOFTWARE or part thereof without specific written permission.
 
-4. This software or any part thereof, including modifications and/or derivative
-works of this software, must be used and execute solely and exclusively on or in
-combination with a microcontroller or microprocessor device manufactured by or
-for STMicroelectronics.
+4. The SOFTWARE or any part thereof, including modifications and/or derivative
+   works of the SOFTWARE, must be used and execute solely and exclusively on or
+   in combination with a processing unit device manufactured by or for
+   STMicroelectronics.
 
-5. No use, reproduction or redistribution of this software partially or totally
-may be done in any manner that would subject this software to any Open Source
-Terms. “Open Source Terms” shall mean any open source license which requires as
-part of distribution of software that the source code of such software is
-distributed therewith or otherwise made available, or open source license that
-substantially complies with the Open Source definition specified at
-www.opensource.org and any other comparable open source license such as for
-example GNU General Public License (GPL), Eclipse Public License (EPL), Apache
-Software License, BSD license or MIT license.
+5. No use, reproduction or redistribution of the SOFTWARE partially or totally
+   may be done in any manner that would subject the SOFTWARE to any Open Source
+   Terms. "Open Source Terms" shall mean any open source license which requires
+   as part of distribution of software that the source code of such software is
+   distributed therewith or otherwise made available, or open source license
+   that substantially complies with the Open Source definition specified at
+   www.opensource.org and any other comparable open source license such as for
+   example GNU General Public License (GPL), Eclipse Public License (EPL),
+   Apache Software License, BSD license or MIT license.
 
 6. STMicroelectronics has no obligation to provide any maintenance, support or
-updates for the software.
+   updates for the SOFTWARE.
 
-7. The software is and will remain the exclusive property of STMicroelectronics
-and its licensors. The recipient will not take any action that jeopardizes
-STMicroelectronics and its licensors' proprietary rights or acquire any rights
-in the software, except the limited rights specified hereunder.
+7. The SOFTWARE is and will remain the exclusive property of STMicroelectronics
+   and its licensors. The RECIPIENT will not take any action that jeopardizes
+   STMicroelectronics and its licensors' proprietary rights or acquire any
+   rights in the SOFTWARE, except the limited rights specified hereunder.
 
-8. The recipient shall comply with all applicable laws and regulations affecting
-the use of the software or any part thereof including any applicable export
-control law or regulation.
+8. The RECIPIENT shall comply with all applicable laws and regulations affecting
+   the use of the SOFTWARE or any part thereof including any applicable export
+   control law or regulation.
 
-9. Redistribution and use of this software or any part thereof other than as
-permitted under this license is void and will automatically terminate your
-rights under this license.
+9. Redistribution and use of the SOFTWARE or any part thereof other than as
+   permitted under this AGREEMENT is void and will automatically terminate
+   RECIPIENT's rights under this AGREEMENT.
 
-10. THIS SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+10. The RECIPIENT shall be solely liable to determine and verify that the
+    SOFTWARE is fit for the RECIPIENT intended use, environment or application
+    and comply with all regulatory, safety and security related requirements
+    concerning any use.
+
+DISCLAIMER:
+
+THE SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY RIGHTS, WHICH ARE
-DISCLAIMED TO THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT SHALL
-STMICROELECTRONICS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
-OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
-ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY RIGHTS, ARE DISCLAIMED TO
+THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT SHALL STMICROELECTRONICS OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THE SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
 
-11. EXCEPT AS EXPRESSLY PERMITTED HEREUNDER, NO LICENSE OR OTHER RIGHTS, WHETHER
-EXPRESS OR IMPLIED, ARE GRANTED UNDER ANY PATENT OR OTHER INTELLECTUAL PROPERTY
-RIGHTS OF STMICROELECTRONICS OR ANY THIRD PARTY.
+EXCEPT AS EXPRESSLY PERMITTED HEREUNDER, NO LICENSE OR OTHER RIGHTS, WHETHER
+EXPRESS OR IMPLIED, ARE GRANTED UNDER ANY PATENT OR OTHER INTELLECTUAL
+PROPERTY RIGHTS OF STMICROELECTRONICS OR ANY THIRD PARTY.


### PR DESCRIPTION
Add REUSE Specification 3.3 (https://reuse.software/spec-3.3/) compliance infrastructure to make all module licenses machine-readable and visible in a SPDX 3.0 Software Bill of Materials.

The repository contains files under four distinct licenses:
- Apache-2.0: stm32cube/*/soc/**, scripts/**, dts/**, CMakeLists.txt
- BSD-3-Clause: stm32cube/*/drivers/**, stm32cube/common_ll/**, stm32cube/stm32c5xx/dfp/**, lib/** (except ll_cmd_lib)
- MIT: lib/stm32wba/STM32_WPAN/link_layer/ll_cmd_lib/**
- LicenseRef-ST-SLA0044: zephyr/blobs/**

Previously these licenses were described only in prose (root LICENSE file and per-directory LICENSE.md files) and had no SPDX-compatible machine-readable form. Approximately 71% of source files lacked in-file SPDX-License-Identifier tags, causing SBOM generators such as 'west spdx' to report NOASSERTION for those files.

Changes:
- Add REUSE.toml with path-glob annotations mapping every file tree to its SPDX license expression, per REUSE spec §3.3.
- Add LICENSES/ directory with canonical full-text copies of:
  * Apache-2.0.txt
  * BSD-3-Clause.txt
  * MIT.txt
  * LicenseRef-ST-SLA0044.txt (ST SLA0044 Rev5/February 2018, copied from zephyr/blobs/stm32wba/lib/license.md)

No source files are modified; upstream STM32Cube content is unchanged.

Assisted-by: GitHub Copilot (Claude Sonnet 4.6)