### PR TITLE
dts: st: add LCD related pinctrl

### DIFF
--- a/dts/st/l0/stm32l053c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053c(6-8)tx-pinctrl.dtsi
@@ -385,6 +385,96 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l053c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053c(6-8)ux-pinctrl.dtsi
@@ -385,6 +385,96 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l053r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053r(6-8)hx-pinctrl.dtsi
@@ -462,6 +462,164 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l053r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053r(6-8)tx-pinctrl.dtsi
@@ -474,6 +474,168 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l063c8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063c8tx-pinctrl.dtsi
@@ -385,6 +385,96 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l063c8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063c8ux-pinctrl.dtsi
@@ -385,6 +385,96 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l063r8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063r8tx-pinctrl.dtsi
@@ -474,6 +474,168 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l073c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073c(b-z)tx-pinctrl.dtsi
@@ -423,6 +423,96 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l073c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073c(b-z)ux-pinctrl.dtsi
@@ -423,6 +423,96 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l073czyx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073czyx-pinctrl.dtsi
@@ -464,6 +464,108 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l073r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073r(b-z)hx-pinctrl.dtsi
@@ -518,6 +518,164 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l073r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073r(b-z)tx-pinctrl.dtsi
@@ -530,6 +530,168 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l073rzix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073rzix-pinctrl.dtsi
@@ -518,6 +518,164 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l073v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v(b-z)ix-pinctrl.dtsi
@@ -680,6 +680,264 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pd3: lcd_seg44_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg45_pe7: lcd_seg45_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg46_pe8: lcd_seg46_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg47_pe9: lcd_seg47_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pe10: lcd_seg40_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pe13: lcd_seg41_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pe14: lcd_seg42_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pe15: lcd_seg43_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l073v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v(b-z)tx-pinctrl.dtsi
@@ -680,6 +680,264 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pd3: lcd_seg44_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg45_pe7: lcd_seg45_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg46_pe8: lcd_seg46_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg47_pe9: lcd_seg47_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pe10: lcd_seg40_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pe13: lcd_seg41_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pe14: lcd_seg42_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pe15: lcd_seg43_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l073v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v8ix-pinctrl.dtsi
@@ -680,6 +680,264 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pd3: lcd_seg44_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg45_pe7: lcd_seg45_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg46_pe8: lcd_seg46_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg47_pe9: lcd_seg47_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pe10: lcd_seg40_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pe13: lcd_seg41_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pe14: lcd_seg42_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pe15: lcd_seg43_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l073v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v8tx-pinctrl.dtsi
@@ -680,6 +680,264 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pd3: lcd_seg44_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg45_pe7: lcd_seg45_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg46_pe8: lcd_seg46_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg47_pe9: lcd_seg47_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pe10: lcd_seg40_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pe13: lcd_seg41_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pe14: lcd_seg42_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pe15: lcd_seg43_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l083c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083c(b-z)tx-pinctrl.dtsi
@@ -423,6 +423,96 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l083czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083czux-pinctrl.dtsi
@@ -423,6 +423,96 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l083r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083r(b-z)hx-pinctrl.dtsi
@@ -518,6 +518,164 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l083r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083r(b-z)tx-pinctrl.dtsi
@@ -530,6 +530,168 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l083v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v(b-z)ix-pinctrl.dtsi
@@ -680,6 +680,264 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pd3: lcd_seg44_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg45_pe7: lcd_seg45_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg46_pe8: lcd_seg46_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg47_pe9: lcd_seg47_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pe10: lcd_seg40_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pe13: lcd_seg41_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pe14: lcd_seg42_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pe15: lcd_seg43_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l083v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v(b-z)tx-pinctrl.dtsi
@@ -680,6 +680,264 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pd3: lcd_seg44_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg45_pe7: lcd_seg45_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg46_pe8: lcd_seg46_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg47_pe9: lcd_seg47_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pe10: lcd_seg40_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pe13: lcd_seg41_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pe14: lcd_seg42_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pe15: lcd_seg43_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l083v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v8ix-pinctrl.dtsi
@@ -680,6 +680,264 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pd3: lcd_seg44_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg45_pe7: lcd_seg45_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg46_pe8: lcd_seg46_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg47_pe9: lcd_seg47_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pe10: lcd_seg40_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pe13: lcd_seg41_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pe14: lcd_seg42_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pe15: lcd_seg43_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l0/stm32l083v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v8tx-pinctrl.dtsi
@@ -680,6 +680,264 @@
 		pinmux = <STM32_PINMUX('A', 14, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pd3: lcd_seg44_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg45_pe7: lcd_seg45_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg46_pe8: lcd_seg46_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg47_pe9: lcd_seg47_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pe10: lcd_seg40_pe10 {
+		pinmux = <STM32_PINMUX('E', 10, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pe13: lcd_seg41_pe13 {
+		pinmux = <STM32_PINMUX('E', 13, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pe14: lcd_seg42_pe14 {
+		pinmux = <STM32_PINMUX('E', 14, AF1)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pe15: lcd_seg43_pe15 {
+		pinmux = <STM32_PINMUX('E', 15, AF1)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l1/stm32l100c6ux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100c6ux-pinctrl.dtsi
@@ -370,6 +370,96 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l100c6uxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100c6uxa-pinctrl.dtsi
@@ -370,6 +370,96 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l100r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100r(8-b)tx-pinctrl.dtsi
@@ -474,6 +474,168 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l100r(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100r(8-b)txa-pinctrl.dtsi
@@ -474,6 +474,168 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l100rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100rctx-pinctrl.dtsi
@@ -543,6 +543,168 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l152c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)tx-pinctrl.dtsi
@@ -370,6 +370,96 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l152c(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)txa-pinctrl.dtsi
@@ -370,6 +370,96 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l152c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)ux-pinctrl.dtsi
@@ -370,6 +370,96 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l152c(6-8-b)uxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)uxa-pinctrl.dtsi
@@ -370,6 +370,96 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l152cctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152cctx-pinctrl.dtsi
@@ -414,6 +414,96 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152ccux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152ccux-pinctrl.dtsi
@@ -414,6 +414,96 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qchx-pinctrl.dtsi
@@ -860,6 +860,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qdhx-pinctrl.dtsi
@@ -860,6 +860,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152qehx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qehx-pinctrl.dtsi
@@ -860,6 +860,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152r(6-8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)hx-pinctrl.dtsi
@@ -462,6 +462,164 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l152r(6-8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)hxa-pinctrl.dtsi
@@ -462,6 +462,180 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l152r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)tx-pinctrl.dtsi
@@ -474,6 +474,168 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l152r(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)txa-pinctrl.dtsi
@@ -474,6 +474,184 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l152rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rctx-pinctrl.dtsi
@@ -539,6 +539,168 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rctxa-pinctrl.dtsi
@@ -539,6 +539,184 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rdtx-pinctrl.dtsi
@@ -539,6 +539,184 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rdyx-pinctrl.dtsi
@@ -539,6 +539,184 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152retx-pinctrl.dtsi
@@ -539,6 +539,184 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152ucyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152ucyx-pinctrl.dtsi
@@ -539,6 +539,168 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)hx-pinctrl.dtsi
@@ -650,6 +650,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l152v(8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)hxa-pinctrl.dtsi
@@ -650,6 +650,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l152v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)tx-pinctrl.dtsi
@@ -650,6 +650,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l152v(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)txa-pinctrl.dtsi
@@ -650,6 +650,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* RCC_MCO */
 
 	/omit-if-no-ref/ rcc_mco_pa8: rcc_mco_pa8 {

--- a/dts/st/l1/stm32l152vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vchx-pinctrl.dtsi
@@ -728,6 +728,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vctx-pinctrl.dtsi
@@ -728,6 +728,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vctxa-pinctrl.dtsi
@@ -728,6 +728,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vdtx-pinctrl.dtsi
@@ -728,6 +728,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152vdtxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vdtxx-pinctrl.dtsi
@@ -728,6 +728,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vetx-pinctrl.dtsi
@@ -728,6 +728,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152veyx-pinctrl.dtsi
@@ -728,6 +728,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zctx-pinctrl.dtsi
@@ -892,6 +892,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zdtx-pinctrl.dtsi
@@ -892,6 +892,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l152zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zetx-pinctrl.dtsi
@@ -892,6 +892,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162qchx-pinctrl.dtsi
@@ -860,6 +860,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162qdhx-pinctrl.dtsi
@@ -860,6 +860,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rctx-pinctrl.dtsi
@@ -539,6 +539,168 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rctxa-pinctrl.dtsi
@@ -539,6 +539,184 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rdtx-pinctrl.dtsi
@@ -539,6 +539,184 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rdyx-pinctrl.dtsi
@@ -539,6 +539,184 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162retx-pinctrl.dtsi
@@ -539,6 +539,184 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vchx-pinctrl.dtsi
@@ -728,6 +728,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vctx-pinctrl.dtsi
@@ -728,6 +728,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vctxa-pinctrl.dtsi
@@ -728,6 +728,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vdtx-pinctrl.dtsi
@@ -728,6 +728,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162vdyxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vdyxx-pinctrl.dtsi
@@ -728,6 +728,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vetx-pinctrl.dtsi
@@ -728,6 +728,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162veyx-pinctrl.dtsi
@@ -728,6 +728,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zctx-pinctrl.dtsi
@@ -892,6 +892,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zdtx-pinctrl.dtsi
@@ -892,6 +892,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l1/stm32l162zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zetx-pinctrl.dtsi
@@ -892,6 +892,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pc3: lcd_seg21_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* OPAMP */
 
 	/omit-if-no-ref/ opamp1_vinp_pa1: opamp1_vinp_pa1 {

--- a/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
@@ -457,6 +457,100 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
@@ -457,6 +457,100 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
@@ -465,6 +465,100 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
@@ -557,6 +557,184 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
@@ -557,6 +557,184 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
@@ -557,6 +557,184 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
@@ -541,6 +541,168 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l433vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vcix-pinctrl.dtsi
@@ -710,6 +710,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l433vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vctx-pinctrl.dtsi
@@ -710,6 +710,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l443ccfx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccfx-pinctrl.dtsi
@@ -465,6 +465,100 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l443cctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443cctx-pinctrl.dtsi
@@ -457,6 +457,100 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l443ccux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccux-pinctrl.dtsi
@@ -457,6 +457,100 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
@@ -465,6 +465,100 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l443rcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcix-pinctrl.dtsi
@@ -557,6 +557,184 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l443rctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rctx-pinctrl.dtsi
@@ -557,6 +557,184 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
@@ -557,6 +557,184 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l443vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vcix-pinctrl.dtsi
@@ -710,6 +710,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l443vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vctx-pinctrl.dtsi
@@ -710,6 +710,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
@@ -670,6 +670,184 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
@@ -650,6 +650,180 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
@@ -727,6 +727,192 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
@@ -1375,6 +1375,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l476qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476qgixp-pinctrl.dtsi
@@ -1375,6 +1375,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
@@ -634,6 +634,184 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
@@ -1068,6 +1068,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l476vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476vgyxp-pinctrl.dtsi
@@ -726,6 +726,172 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
@@ -1415,6 +1415,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
@@ -1415,6 +1415,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
@@ -1387,6 +1387,228 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
@@ -670,6 +670,184 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l486qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486qgix-pinctrl.dtsi
@@ -1375,6 +1375,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
@@ -634,6 +634,184 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
@@ -1068,6 +1068,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
@@ -1415,6 +1415,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pb2: lptim1_out_pb2 {

--- a/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
@@ -1926,6 +1926,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496agixp-pinctrl.dtsi
@@ -1903,6 +1903,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
@@ -1675,6 +1675,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
@@ -1634,6 +1634,228 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496qgixs-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixs-pinctrl.dtsi
@@ -1675,6 +1675,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
@@ -833,6 +833,184 @@
 		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
@@ -804,6 +804,168 @@
 		pinmux = <STM32_PINMUX('C', 12, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
@@ -1329,6 +1329,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
@@ -1289,6 +1289,224 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
@@ -1242,6 +1242,212 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
@@ -1226,6 +1226,208 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
@@ -1353,6 +1353,204 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
@@ -1720,6 +1720,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
@@ -1681,6 +1681,228 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
@@ -1926,6 +1926,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
@@ -1903,6 +1903,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
@@ -1675,6 +1675,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
@@ -1634,6 +1634,228 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
@@ -833,6 +833,184 @@
 		pinmux = <STM32_PINMUX('D', 2, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
@@ -804,6 +804,168 @@
 		pinmux = <STM32_PINMUX('C', 12, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
@@ -1329,6 +1329,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
@@ -1289,6 +1289,224 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
@@ -1242,6 +1242,212 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
@@ -1226,6 +1226,208 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
@@ -1720,6 +1720,232 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
@@ -1681,6 +1681,228 @@
 		pinmux = <STM32_PINMUX('E', 6, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pe3: lcd_seg39_pe3 {
+		pinmux = <STM32_PINMUX('E', 3, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/u0/stm32u073c8tx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073c8tx-pinctrl.dtsi
@@ -504,6 +504,120 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073c8ux-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073c8ux-pinctrl.dtsi
@@ -504,6 +504,120 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073cbtx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073cbtx-pinctrl.dtsi
@@ -504,6 +504,120 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073cbux-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073cbux-pinctrl.dtsi
@@ -504,6 +504,120 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073cctx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073cctx-pinctrl.dtsi
@@ -504,6 +504,120 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073ccux-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073ccux-pinctrl.dtsi
@@ -504,6 +504,120 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073h8yx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073h8yx-pinctrl.dtsi
@@ -440,6 +440,96 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073hbyx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073hbyx-pinctrl.dtsi
@@ -440,6 +440,96 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073hcyx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073hcyx-pinctrl.dtsi
@@ -440,6 +440,96 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073k8ux-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073k8ux-pinctrl.dtsi
@@ -384,6 +384,88 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073kbux-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073kbux-pinctrl.dtsi
@@ -384,6 +384,88 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073kcux-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073kcux-pinctrl.dtsi
@@ -384,6 +384,88 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073m8ix-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073m8ix-pinctrl.dtsi
@@ -700,6 +700,264 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd0: lcd_seg34_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd1: lcd_seg35_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pd3: lcd_seg36_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pd4: lcd_seg37_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pd5: lcd_seg38_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pd6: lcd_seg39_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg45_pe7: lcd_seg45_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg46_pe8: lcd_seg46_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg47_pe9: lcd_seg47_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073m8tx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073m8tx-pinctrl.dtsi
@@ -696,6 +696,264 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd0: lcd_seg34_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd1: lcd_seg35_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pd3: lcd_seg36_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pd4: lcd_seg37_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pd5: lcd_seg38_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pd6: lcd_seg39_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg45_pe7: lcd_seg45_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg46_pe8: lcd_seg46_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg47_pe9: lcd_seg47_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073mbix-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073mbix-pinctrl.dtsi
@@ -700,6 +700,264 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd0: lcd_seg34_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd1: lcd_seg35_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pd3: lcd_seg36_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pd4: lcd_seg37_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pd5: lcd_seg38_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pd6: lcd_seg39_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg45_pe7: lcd_seg45_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg46_pe8: lcd_seg46_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg47_pe9: lcd_seg47_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073mbtx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073mbtx-pinctrl.dtsi
@@ -696,6 +696,264 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd0: lcd_seg34_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd1: lcd_seg35_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pd3: lcd_seg36_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pd4: lcd_seg37_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pd5: lcd_seg38_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pd6: lcd_seg39_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg45_pe7: lcd_seg45_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg46_pe8: lcd_seg46_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg47_pe9: lcd_seg47_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073mcix-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073mcix-pinctrl.dtsi
@@ -700,6 +700,264 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd0: lcd_seg34_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd1: lcd_seg35_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pd3: lcd_seg36_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pd4: lcd_seg37_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pd5: lcd_seg38_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pd6: lcd_seg39_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg45_pe7: lcd_seg45_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg46_pe8: lcd_seg46_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg47_pe9: lcd_seg47_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073mctx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073mctx-pinctrl.dtsi
@@ -696,6 +696,264 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd0: lcd_seg34_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd1: lcd_seg35_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pd3: lcd_seg36_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pd4: lcd_seg37_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pd5: lcd_seg38_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pd6: lcd_seg39_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg45_pe7: lcd_seg45_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg46_pe8: lcd_seg46_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg47_pe9: lcd_seg47_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073r8ix-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073r8ix-pinctrl.dtsi
@@ -620,6 +620,204 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073r8tx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073r8tx-pinctrl.dtsi
@@ -620,6 +620,204 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073rbix-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073rbix-pinctrl.dtsi
@@ -620,6 +620,204 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073rbtx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073rbtx-pinctrl.dtsi
@@ -620,6 +620,204 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073rcix-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073rcix-pinctrl.dtsi
@@ -620,6 +620,204 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u073rctx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073rctx-pinctrl.dtsi
@@ -620,6 +620,204 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u083cctx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u083cctx-pinctrl.dtsi
@@ -504,6 +504,120 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u083ccux-pinctrl.dtsi
+++ b/dts/st/u0/stm32u083ccux-pinctrl.dtsi
@@ -504,6 +504,120 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u083hcyx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u083hcyx-pinctrl.dtsi
@@ -440,6 +440,96 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u083kcux-pinctrl.dtsi
+++ b/dts/st/u0/stm32u083kcux-pinctrl.dtsi
@@ -384,6 +384,88 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u083mcix-pinctrl.dtsi
+++ b/dts/st/u0/stm32u083mcix-pinctrl.dtsi
@@ -700,6 +700,264 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd0: lcd_seg34_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd1: lcd_seg35_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pd3: lcd_seg36_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pd4: lcd_seg37_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pd5: lcd_seg38_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pd6: lcd_seg39_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg45_pe7: lcd_seg45_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg46_pe8: lcd_seg46_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg47_pe9: lcd_seg47_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u083mctx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u083mctx-pinctrl.dtsi
@@ -696,6 +696,264 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd0: lcd_seg34_pd0 {
+		pinmux = <STM32_PINMUX('D', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd1: lcd_seg35_pd1 {
+		pinmux = <STM32_PINMUX('D', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pd3: lcd_seg36_pd3 {
+		pinmux = <STM32_PINMUX('D', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pd4: lcd_seg37_pd4 {
+		pinmux = <STM32_PINMUX('D', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pd5: lcd_seg38_pd5 {
+		pinmux = <STM32_PINMUX('D', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pd6: lcd_seg39_pd6 {
+		pinmux = <STM32_PINMUX('D', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg45_pe7: lcd_seg45_pe7 {
+		pinmux = <STM32_PINMUX('E', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg46_pe8: lcd_seg46_pe8 {
+		pinmux = <STM32_PINMUX('E', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg47_pe9: lcd_seg47_pe9 {
+		pinmux = <STM32_PINMUX('E', 9, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u083rcix-pinctrl.dtsi
+++ b/dts/st/u0/stm32u083rcix-pinctrl.dtsi
@@ -620,6 +620,204 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/u0/stm32u083rctx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u083rctx-pinctrl.dtsi
@@ -620,6 +620,204 @@
 		pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg42_pa0: lcd_seg42_pa0 {
+		pinmux = <STM32_PINMUX('A', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pa4: lcd_seg43_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg44_pa5: lcd_seg44_pa5 {
+		pinmux = <STM32_PINMUX('A', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pa13: lcd_seg40_pa13 {
+		pinmux = <STM32_PINMUX('A', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pa14: lcd_seg41_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pb0: lcd_seg5_pb0 {
+		pinmux = <STM32_PINMUX('B', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb1: lcd_seg6_pb1 {
+		pinmux = <STM32_PINMUX('B', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg48_pc10: lcd_seg48_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg49_pc11: lcd_seg49_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg50_pc12: lcd_seg50_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg51_pd2: lcd_seg51_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_ch2_pa1: lptim1_ch2_pa1 {

--- a/dts/st/wb/stm32wb55ccux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55ccux-pinctrl.dtsi
@@ -348,6 +348,80 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa4: lcd_seg5_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa14: lcd_seg5_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb6: lcd_seg6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb55ceux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55ceux-pinctrl.dtsi
@@ -348,6 +348,80 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa4: lcd_seg5_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa14: lcd_seg5_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb6: lcd_seg6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb55cgux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55cgux-pinctrl.dtsi
@@ -348,6 +348,80 @@
 		pinmux = <STM32_PINMUX('B', 4, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa4: lcd_seg5_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa14: lcd_seg5_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb6: lcd_seg6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
@@ -513,6 +513,164 @@
 		pinmux = <STM32_PINMUX('C', 12, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa4: lcd_seg5_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa14: lcd_seg5_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb6: lcd_seg6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb55revx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55revx-pinctrl.dtsi
@@ -513,6 +513,164 @@
 		pinmux = <STM32_PINMUX('C', 12, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa4: lcd_seg5_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa14: lcd_seg5_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb6: lcd_seg6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
@@ -513,6 +513,164 @@
 		pinmux = <STM32_PINMUX('C', 12, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa4: lcd_seg5_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa14: lcd_seg5_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb6: lcd_seg6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
@@ -617,6 +617,236 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa4: lcd_seg5_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa14: lcd_seg5_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb6: lcd_seg6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pd7: lcd_seg39_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
@@ -617,6 +617,236 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa4: lcd_seg5_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa14: lcd_seg5_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb6: lcd_seg6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pd7: lcd_seg39_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
@@ -617,6 +617,236 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa4: lcd_seg5_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa14: lcd_seg5_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb6: lcd_seg6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pd7: lcd_seg39_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
@@ -617,6 +617,236 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa4: lcd_seg5_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa14: lcd_seg5_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb6: lcd_seg6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pd7: lcd_seg39_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
@@ -617,6 +617,236 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa4: lcd_seg5_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa14: lcd_seg5_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb6: lcd_seg6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pd7: lcd_seg39_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
@@ -617,6 +617,236 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa4: lcd_seg5_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa14: lcd_seg5_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb6: lcd_seg6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pd7: lcd_seg39_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb55vyyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vyyx-pinctrl.dtsi
@@ -617,6 +617,236 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa4: lcd_seg5_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa14: lcd_seg5_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb6: lcd_seg6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pd7: lcd_seg39_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
@@ -609,6 +609,236 @@
 		pinmux = <STM32_PINMUX('E', 2, AF0)>;
 	};
 
+	/* LCD */
+
+	/omit-if-no-ref/ lcd_seg0_pa1: lcd_seg0_pa1 {
+		pinmux = <STM32_PINMUX('A', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg1_pa2: lcd_seg1_pa2 {
+		pinmux = <STM32_PINMUX('A', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg2_pa3: lcd_seg2_pa3 {
+		pinmux = <STM32_PINMUX('A', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa4: lcd_seg5_pa4 {
+		pinmux = <STM32_PINMUX('A', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg3_pa6: lcd_seg3_pa6 {
+		pinmux = <STM32_PINMUX('A', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg4_pa7: lcd_seg4_pa7 {
+		pinmux = <STM32_PINMUX('A', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com0_pa8: lcd_com0_pa8 {
+		pinmux = <STM32_PINMUX('A', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com1_pa9: lcd_com1_pa9 {
+		pinmux = <STM32_PINMUX('A', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com2_pa10: lcd_com2_pa10 {
+		pinmux = <STM32_PINMUX('A', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg5_pa14: lcd_seg5_pa14 {
+		pinmux = <STM32_PINMUX('A', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg17_pa15: lcd_seg17_pa15 {
+		pinmux = <STM32_PINMUX('A', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
+		pinmux = <STM32_PINMUX('B', 3, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg8_pb4: lcd_seg8_pb4 {
+		pinmux = <STM32_PINMUX('B', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg9_pb5: lcd_seg9_pb5 {
+		pinmux = <STM32_PINMUX('B', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg6_pb6: lcd_seg6_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg21_pb7: lcd_seg21_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg16_pb8: lcd_seg16_pb8 {
+		pinmux = <STM32_PINMUX('B', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com3_pb9: lcd_com3_pb9 {
+		pinmux = <STM32_PINMUX('B', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg10_pb10: lcd_seg10_pb10 {
+		pinmux = <STM32_PINMUX('B', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg11_pb11: lcd_seg11_pb11 {
+		pinmux = <STM32_PINMUX('B', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg12_pb12: lcd_seg12_pb12 {
+		pinmux = <STM32_PINMUX('B', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg13_pb13: lcd_seg13_pb13 {
+		pinmux = <STM32_PINMUX('B', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg14_pb14: lcd_seg14_pb14 {
+		pinmux = <STM32_PINMUX('B', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
+		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg18_pc0: lcd_seg18_pc0 {
+		pinmux = <STM32_PINMUX('C', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg19_pc1: lcd_seg19_pc1 {
+		pinmux = <STM32_PINMUX('C', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
+		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
+		pinmux = <STM32_PINMUX('C', 4, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg23_pc5: lcd_seg23_pc5 {
+		pinmux = <STM32_PINMUX('C', 5, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg24_pc6: lcd_seg24_pc6 {
+		pinmux = <STM32_PINMUX('C', 6, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg25_pc7: lcd_seg25_pc7 {
+		pinmux = <STM32_PINMUX('C', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg26_pc8: lcd_seg26_pc8 {
+		pinmux = <STM32_PINMUX('C', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg27_pc9: lcd_seg27_pc9 {
+		pinmux = <STM32_PINMUX('C', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com4_pc10: lcd_com4_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pc10: lcd_seg28_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg40_pc10: lcd_seg40_pc10 {
+		pinmux = <STM32_PINMUX('C', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com5_pc11: lcd_com5_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pc11: lcd_seg29_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg41_pc11: lcd_seg41_pc11 {
+		pinmux = <STM32_PINMUX('C', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com6_pc12: lcd_com6_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pc12: lcd_seg30_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg42_pc12: lcd_seg42_pc12 {
+		pinmux = <STM32_PINMUX('C', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_com7_pd2: lcd_com7_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd2: lcd_seg31_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg43_pd2: lcd_seg43_pd2 {
+		pinmux = <STM32_PINMUX('D', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg39_pd7: lcd_seg39_pd7 {
+		pinmux = <STM32_PINMUX('D', 7, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg28_pd8: lcd_seg28_pd8 {
+		pinmux = <STM32_PINMUX('D', 8, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg29_pd9: lcd_seg29_pd9 {
+		pinmux = <STM32_PINMUX('D', 9, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg30_pd10: lcd_seg30_pd10 {
+		pinmux = <STM32_PINMUX('D', 10, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg31_pd11: lcd_seg31_pd11 {
+		pinmux = <STM32_PINMUX('D', 11, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg32_pd12: lcd_seg32_pd12 {
+		pinmux = <STM32_PINMUX('D', 12, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg33_pd13: lcd_seg33_pd13 {
+		pinmux = <STM32_PINMUX('D', 13, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg34_pd14: lcd_seg34_pd14 {
+		pinmux = <STM32_PINMUX('D', 14, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg35_pd15: lcd_seg35_pd15 {
+		pinmux = <STM32_PINMUX('D', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg36_pe0: lcd_seg36_pe0 {
+		pinmux = <STM32_PINMUX('E', 0, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg37_pe1: lcd_seg37_pe1 {
+		pinmux = <STM32_PINMUX('E', 1, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_seg38_pe2: lcd_seg38_pe2 {
+		pinmux = <STM32_PINMUX('E', 2, AF11)>;
+	};
+
 	/* LPTIM */
 
 	/omit-if-no-ref/ lptim1_out_pa14: lptim1_out_pa14 {

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -170,6 +170,9 @@
 - name: JTAG PORT
   match: "^(SYS|DEBUG)_((JTMS-?)?SWDIO|(JTCK-?)?SWCLK|JTDI|(JTDO-?)?(TRACESWO|SWO)?|(N)?JTRST|TRACECLK|TRACED\\d)$"
 
+- name: LCD
+  match: "^LCD_(SEG([0-9]|[1-4][0-9]|5[0-1])|COM[0-7])$"
+
 - name: LPTIM
   match: "^LPTIM[1-6]_(IN[1-2]|CH[1-4]|ETR|OUT)$"
 


### PR DESCRIPTION
Update the stm32-pinctrl-config.yaml to also generate LCD related pinctrls and generate all of them.