### PR TITLE
stm32Cube: stm32u5 HAL ospi driver adds memory type and size functions

### DIFF
--- a/stm32cube/stm32u5xx/drivers/include/stm32u5xx_hal_ospi.h
+++ b/stm32cube/stm32u5xx/drivers/include/stm32u5xx_hal_ospi.h
@@ -869,6 +869,8 @@ HAL_StatusTypeDef     HAL_OSPI_Abort(OSPI_HandleTypeDef *hospi);
 HAL_StatusTypeDef     HAL_OSPI_Abort_IT(OSPI_HandleTypeDef *hospi);
 HAL_StatusTypeDef     HAL_OSPI_SetFifoThreshold(OSPI_HandleTypeDef *hospi, uint32_t Threshold);
 uint32_t              HAL_OSPI_GetFifoThreshold(const OSPI_HandleTypeDef *hospi);
+HAL_StatusTypeDef     HAL_OSPI_SetMemoryType(OSPI_HandleTypeDef *hospi, uint32_t Type);
+HAL_StatusTypeDef     HAL_OSPI_SetDeviceSize(OSPI_HandleTypeDef *hospi, uint32_t Size);
 HAL_StatusTypeDef     HAL_OSPI_SetTimeout(OSPI_HandleTypeDef *hospi, uint32_t Timeout);
 uint32_t              HAL_OSPI_GetError(const OSPI_HandleTypeDef *hospi);
 uint32_t              HAL_OSPI_GetState(const OSPI_HandleTypeDef *hospi);

--- a/stm32cube/stm32u5xx/drivers/src/stm32u5xx_hal_ospi.c
+++ b/stm32cube/stm32u5xx/drivers/src/stm32u5xx_hal_ospi.c
@@ -2550,6 +2550,65 @@ uint32_t HAL_OSPI_GetFifoThreshold(const OSPI_HandleTypeDef *hospi)
   return ((READ_BIT(hospi->Instance->CR, OCTOSPI_CR_FTHRES) >> OCTOSPI_CR_FTHRES_Pos) + 1U);
 }
 
+/** @brief  Set OSPI Memory Type.
+  * @param  hospi : OSPI handle.
+  * @param  Type : Memory Type.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_OSPI_SetMemoryType(OSPI_HandleTypeDef *hospi, uint32_t Type)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  assert_param(IS_OSPI_MEMORY_TYPE(Type));
+
+  /* Check the state */
+  if ((hospi->State & OSPI_BUSY_STATE_MASK) == 0U)
+  {
+    /* Synchronize initialization structure with the new memory type value */
+    hospi->Init.MemoryType = Type;
+
+    /* Configure new memory type */
+    MODIFY_REG(hospi->Instance->DCR1, OCTOSPI_DCR1_MTYP, hospi->Init.MemoryType);
+  }
+  else
+  {
+    status = HAL_ERROR;
+    hospi->ErrorCode = HAL_OSPI_ERROR_INVALID_SEQUENCE;
+  }
+
+  return status;
+}
+
+/** @brief  Set OSPI Device Size.
+  * @param  hospi : OSPI handle.
+  * @param  Size : Device Size.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_OSPI_SetDeviceSize(OSPI_HandleTypeDef *hospi, uint32_t Size)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  assert_param(IS_OSPI_MEMORY_SIZE(Size));
+
+  /* Check the state */
+  if ((hospi->State & OSPI_BUSY_STATE_MASK) == 0U)
+  {
+    /* Synchronize initialization structure with the new device size value */
+    hospi->Init.MemorySize = Size;
+
+    /* Configure new device size */
+    MODIFY_REG(hospi->Instance->DCR1, OCTOSPI_DCR1_DEVSIZE,
+               (hospi->Init.MemorySize << OCTOSPI_DCR1_DEVSIZE_Pos));
+  }
+  else
+  {
+    status = HAL_ERROR;
+    hospi->ErrorCode = HAL_OSPI_ERROR_INVALID_SEQUENCE;
+  }
+
+  return status;
+}
+
 /** @brief Set OSPI timeout.
   * @param  hospi   : OSPI handle.
   * @param  Timeout : Timeout for the memory access.


### PR DESCRIPTION
Add HAL_OSPI_SetMemoryType and HAL_OSPI_SetMemorySize API functions to the stm32U5 HAL driver to set the DCR1 register out of init Same model has the XSPi HAL driver functions.
This is required for the mspi flash ospi driver

Adding to the stm32u5xx/drivers
HAL_OSPI_SetMemoryType(OSPI_HandleTypeDef *hospi, uint32_t Type);
HAL_OSPI_SetDeviceSize(OSPI_HandleTypeDef *hospi, uint32_t Size);

