### PR TITLE
Add missing LCD_VLCD pinctrl in hal_stm32

### DIFF
--- a/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
@@ -503,6 +503,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};

--- a/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
@@ -503,6 +503,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};

--- a/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
@@ -511,6 +511,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -557,6 +561,10 @@
 
 	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
@@ -603,6 +603,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -661,6 +665,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
@@ -603,6 +603,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -661,6 +665,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
@@ -603,6 +603,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -661,6 +665,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
@@ -587,6 +587,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -645,6 +649,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l433vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vcix-pinctrl.dtsi
@@ -756,6 +756,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -814,6 +818,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l433vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vctx-pinctrl.dtsi
@@ -756,6 +756,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -814,6 +818,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l443ccfx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccfx-pinctrl.dtsi
@@ -511,6 +511,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -557,6 +561,10 @@
 
 	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l443cctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443cctx-pinctrl.dtsi
@@ -503,6 +503,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};

--- a/dts/st/l4/stm32l443ccux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccux-pinctrl.dtsi
@@ -503,6 +503,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};

--- a/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
@@ -511,6 +511,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -557,6 +561,10 @@
 
 	/omit-if-no-ref/ lcd_seg15_pb15: lcd_seg15_pb15 {
 		pinmux = <STM32_PINMUX('B', 15, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/* LPTIM */

--- a/dts/st/l4/stm32l443rcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcix-pinctrl.dtsi
@@ -603,6 +603,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -661,6 +665,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l443rctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rctx-pinctrl.dtsi
@@ -603,6 +603,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -661,6 +665,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
@@ -603,6 +603,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -661,6 +665,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l443vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vcix-pinctrl.dtsi
@@ -756,6 +756,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -814,6 +818,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l443vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vctx-pinctrl.dtsi
@@ -756,6 +756,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -814,6 +818,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
@@ -776,6 +776,10 @@
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
 		pinmux = <STM32_PINMUX('C', 4, AF11)>;
 	};

--- a/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
@@ -756,6 +756,10 @@
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
 		pinmux = <STM32_PINMUX('C', 4, AF11)>;
 	};

--- a/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
@@ -833,6 +833,10 @@
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
 		pinmux = <STM32_PINMUX('C', 4, AF11)>;
 	};

--- a/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
@@ -1481,6 +1481,10 @@
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
 		pinmux = <STM32_PINMUX('C', 4, AF11)>;
 	};

--- a/dts/st/l4/stm32l476qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476qgixp-pinctrl.dtsi
@@ -1481,6 +1481,10 @@
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
 		pinmux = <STM32_PINMUX('C', 4, AF11)>;
 	};

--- a/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
@@ -740,6 +740,10 @@
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
 		pinmux = <STM32_PINMUX('C', 4, AF11)>;
 	};

--- a/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
@@ -1174,6 +1174,10 @@
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
 		pinmux = <STM32_PINMUX('C', 4, AF11)>;
 	};

--- a/dts/st/l4/stm32l476vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476vgyxp-pinctrl.dtsi
@@ -832,6 +832,10 @@
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
 		pinmux = <STM32_PINMUX('C', 4, AF11)>;
 	};

--- a/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
@@ -1521,6 +1521,10 @@
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
 		pinmux = <STM32_PINMUX('C', 4, AF11)>;
 	};

--- a/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
@@ -1521,6 +1521,10 @@
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
 		pinmux = <STM32_PINMUX('C', 4, AF11)>;
 	};

--- a/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
@@ -1489,6 +1489,10 @@
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
 		pinmux = <STM32_PINMUX('C', 4, AF11)>;
 	};

--- a/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
@@ -776,6 +776,10 @@
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
 		pinmux = <STM32_PINMUX('C', 4, AF11)>;
 	};

--- a/dts/st/l4/stm32l486qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486qgix-pinctrl.dtsi
@@ -1481,6 +1481,10 @@
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
 		pinmux = <STM32_PINMUX('C', 4, AF11)>;
 	};

--- a/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
@@ -740,6 +740,10 @@
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
 		pinmux = <STM32_PINMUX('C', 4, AF11)>;
 	};

--- a/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
@@ -1174,6 +1174,10 @@
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
 		pinmux = <STM32_PINMUX('C', 4, AF11)>;
 	};

--- a/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
@@ -1521,6 +1521,10 @@
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {
 		pinmux = <STM32_PINMUX('C', 4, AF11)>;
 	};

--- a/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
@@ -1972,6 +1972,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -2030,6 +2034,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l496agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496agixp-pinctrl.dtsi
@@ -1949,6 +1949,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -2007,6 +2011,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
@@ -1721,6 +1721,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -1779,6 +1783,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
@@ -1680,6 +1680,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -1734,6 +1738,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l496qgixs-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixs-pinctrl.dtsi
@@ -1721,6 +1721,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -1779,6 +1783,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
@@ -879,6 +879,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -937,6 +941,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
@@ -850,6 +850,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -908,6 +912,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
@@ -1375,6 +1375,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -1433,6 +1437,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
@@ -1335,6 +1335,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -1389,6 +1393,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
@@ -1288,6 +1288,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -1346,6 +1350,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
@@ -1272,6 +1272,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -1330,6 +1334,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
@@ -1399,6 +1399,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -1449,6 +1453,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
@@ -1766,6 +1766,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -1824,6 +1828,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
@@ -1727,6 +1727,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -1781,6 +1785,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
@@ -1972,6 +1972,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -2030,6 +2034,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
@@ -1949,6 +1949,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -2007,6 +2011,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
@@ -1721,6 +1721,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -1779,6 +1783,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
@@ -1680,6 +1680,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -1734,6 +1738,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
@@ -879,6 +879,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -937,6 +941,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
@@ -850,6 +850,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -908,6 +912,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
@@ -1375,6 +1375,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -1433,6 +1437,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
@@ -1335,6 +1335,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -1389,6 +1393,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
@@ -1288,6 +1288,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -1346,6 +1350,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
@@ -1272,6 +1272,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -1330,6 +1334,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
@@ -1766,6 +1766,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -1824,6 +1828,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
@@ -1727,6 +1727,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -1781,6 +1785,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/u0/stm32u073c8tx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073c8tx-pinctrl.dtsi
@@ -570,6 +570,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};

--- a/dts/st/u0/stm32u073c8ux-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073c8ux-pinctrl.dtsi
@@ -570,6 +570,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};

--- a/dts/st/u0/stm32u073cbtx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073cbtx-pinctrl.dtsi
@@ -570,6 +570,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};

--- a/dts/st/u0/stm32u073cbux-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073cbux-pinctrl.dtsi
@@ -570,6 +570,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};

--- a/dts/st/u0/stm32u073cctx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073cctx-pinctrl.dtsi
@@ -570,6 +570,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};

--- a/dts/st/u0/stm32u073ccux-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073ccux-pinctrl.dtsi
@@ -570,6 +570,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};

--- a/dts/st/u0/stm32u073h8yx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073h8yx-pinctrl.dtsi
@@ -506,6 +506,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};

--- a/dts/st/u0/stm32u073hbyx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073hbyx-pinctrl.dtsi
@@ -506,6 +506,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};

--- a/dts/st/u0/stm32u073hcyx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073hcyx-pinctrl.dtsi
@@ -506,6 +506,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};

--- a/dts/st/u0/stm32u073m8ix-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073m8ix-pinctrl.dtsi
@@ -766,6 +766,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -824,6 +828,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/u0/stm32u073m8tx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073m8tx-pinctrl.dtsi
@@ -762,6 +762,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -820,6 +824,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/u0/stm32u073mbix-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073mbix-pinctrl.dtsi
@@ -766,6 +766,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -824,6 +828,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/u0/stm32u073mbtx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073mbtx-pinctrl.dtsi
@@ -762,6 +762,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -820,6 +824,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/u0/stm32u073mcix-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073mcix-pinctrl.dtsi
@@ -766,6 +766,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -824,6 +828,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/u0/stm32u073mctx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073mctx-pinctrl.dtsi
@@ -762,6 +762,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -820,6 +824,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/u0/stm32u073r8ix-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073r8ix-pinctrl.dtsi
@@ -686,6 +686,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -744,6 +748,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/u0/stm32u073r8tx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073r8tx-pinctrl.dtsi
@@ -686,6 +686,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -744,6 +748,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/u0/stm32u073rbix-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073rbix-pinctrl.dtsi
@@ -686,6 +686,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -744,6 +748,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/u0/stm32u073rbtx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073rbtx-pinctrl.dtsi
@@ -686,6 +686,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -744,6 +748,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/u0/stm32u073rcix-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073rcix-pinctrl.dtsi
@@ -686,6 +686,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -744,6 +748,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/u0/stm32u073rctx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u073rctx-pinctrl.dtsi
@@ -686,6 +686,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -744,6 +748,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/u0/stm32u083cctx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u083cctx-pinctrl.dtsi
@@ -570,6 +570,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};

--- a/dts/st/u0/stm32u083ccux-pinctrl.dtsi
+++ b/dts/st/u0/stm32u083ccux-pinctrl.dtsi
@@ -570,6 +570,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};

--- a/dts/st/u0/stm32u083hcyx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u083hcyx-pinctrl.dtsi
@@ -506,6 +506,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};

--- a/dts/st/u0/stm32u083mcix-pinctrl.dtsi
+++ b/dts/st/u0/stm32u083mcix-pinctrl.dtsi
@@ -766,6 +766,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -824,6 +828,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/u0/stm32u083mctx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u083mctx-pinctrl.dtsi
@@ -762,6 +762,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -820,6 +824,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/u0/stm32u083rcix-pinctrl.dtsi
+++ b/dts/st/u0/stm32u083rcix-pinctrl.dtsi
@@ -686,6 +686,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -744,6 +748,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/u0/stm32u083rctx-pinctrl.dtsi
+++ b/dts/st/u0/stm32u083rctx-pinctrl.dtsi
@@ -686,6 +686,10 @@
 		pinmux = <STM32_PINMUX('B', 1, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -744,6 +748,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/wb/stm32wb55ccux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55ccux-pinctrl.dtsi
@@ -394,6 +394,10 @@
 		pinmux = <STM32_PINMUX('A', 15, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};

--- a/dts/st/wb/stm32wb55ceux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55ceux-pinctrl.dtsi
@@ -394,6 +394,10 @@
 		pinmux = <STM32_PINMUX('A', 15, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};

--- a/dts/st/wb/stm32wb55cgux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55cgux-pinctrl.dtsi
@@ -394,6 +394,10 @@
 		pinmux = <STM32_PINMUX('A', 15, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};

--- a/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
@@ -559,6 +559,10 @@
 		pinmux = <STM32_PINMUX('A', 15, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -621,6 +625,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/wb/stm32wb55revx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55revx-pinctrl.dtsi
@@ -559,6 +559,10 @@
 		pinmux = <STM32_PINMUX('A', 15, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -621,6 +625,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
@@ -559,6 +559,10 @@
 		pinmux = <STM32_PINMUX('A', 15, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -621,6 +625,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
@@ -663,6 +663,10 @@
 		pinmux = <STM32_PINMUX('A', 15, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -725,6 +729,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
@@ -663,6 +663,10 @@
 		pinmux = <STM32_PINMUX('A', 15, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -725,6 +729,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
@@ -663,6 +663,10 @@
 		pinmux = <STM32_PINMUX('A', 15, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -725,6 +729,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
@@ -663,6 +663,10 @@
 		pinmux = <STM32_PINMUX('A', 15, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -725,6 +729,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
@@ -663,6 +663,10 @@
 		pinmux = <STM32_PINMUX('A', 15, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -725,6 +729,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
@@ -663,6 +663,10 @@
 		pinmux = <STM32_PINMUX('A', 15, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -725,6 +729,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/wb/stm32wb55vyyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vyyx-pinctrl.dtsi
@@ -663,6 +663,10 @@
 		pinmux = <STM32_PINMUX('A', 15, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -725,6 +729,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
@@ -655,6 +655,10 @@
 		pinmux = <STM32_PINMUX('A', 15, AF11)>;
 	};
 
+	/omit-if-no-ref/ lcd_vlcd_pb2: lcd_vlcd_pb2 {
+		pinmux = <STM32_PINMUX('B', 2, AF11)>;
+	};
+
 	/omit-if-no-ref/ lcd_seg7_pb3: lcd_seg7_pb3 {
 		pinmux = <STM32_PINMUX('B', 3, AF11)>;
 	};
@@ -717,6 +721,10 @@
 
 	/omit-if-no-ref/ lcd_seg20_pc2: lcd_seg20_pc2 {
 		pinmux = <STM32_PINMUX('C', 2, AF11)>;
+	};
+
+	/omit-if-no-ref/ lcd_vlcd_pc3: lcd_vlcd_pc3 {
+		pinmux = <STM32_PINMUX('C', 3, AF11)>;
 	};
 
 	/omit-if-no-ref/ lcd_seg22_pc4: lcd_seg22_pc4 {

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -171,7 +171,7 @@
   match: "^(SYS|DEBUG)_((JTMS-?)?SWDIO|(JTCK-?)?SWCLK|JTDI|(JTDO-?)?(TRACESWO|SWO)?|(N)?JTRST|TRACECLK|TRACED\\d)$"
 
 - name: LCD
-  match: "^LCD_(SEG([0-9]|[1-4][0-9]|5[0-1])|COM[0-7])$"
+  match: "^LCD_(SEG([0-9]|[1-4][0-9]|5[0-1])|COM[0-7]|VLCD)$"
 
 - name: LPTIM
   match: "^LPTIM[1-6]_(IN[1-2]|CH[1-4]|ETR|OUT)$"


### PR DESCRIPTION
This PR is a follow-up of PR https://github.com/zephyrproject-rtos/hal_stm32/pull/389 in order to add the pinctrl of LCD_VLCD pin which was missing in the first PR.