### PR TITLE
stm32cube: stm32h7: fix clang compilation

### DIFF
--- a/stm32cube/stm32h7xx/soc/system_stm32h7xx.h
+++ b/stm32cube/stm32h7xx/soc/system_stm32h7xx.h
@@ -84,7 +84,7 @@ extern const  uint8_t D1CorePrescTable[16] ; /*!< D1CorePrescTable prescalers ta
 
 extern void SystemInit(void);
 extern void SystemCoreClockUpdate(void);
-#if defined(__GNUC__) && !defined(__ARMCC_VERSION)
+#if defined(__GNUC__) && !defined(__ARMCC_VERSION) && !defined(__clang__)
   extern void ExitRun0Mode(void) __attribute__((optimize("Os")));
 #else
   extern void ExitRun0Mode(void);


### PR DESCRIPTION
LLVM defines the __GNUC__ macro but does not support the optimize attribute, at least per the 24.0.0 version:
https://clang.llvm.org/docs/AttributeReference.html

Fix the unknown attribute compilation error by adding a compile-time guard for Clang specifically.