### PR TITLE
stm32cube: stm32h7: fix SDMMC IRQ storm on data error in IT transfers

### DIFF
--- a/stm32cube/stm32h7xx/README
+++ b/stm32cube/stm32h7xx/README
@@ -63,4 +63,14 @@ Patch List:
      - Impacted file: drivers/include/stm32h7xx_ll_system.h
      - See also: https://github.com/zephyrproject-rtos/hal_stm32/pull/381
 
+   *Fix SDMMC interrupt storm on data error during interrupt-mode transfers
+     When a data error (TXUNDERR, RXOVERR, DCRCFAIL, DTIMEOUT) occurs during an
+     interrupt-mode SD transfer, HAL_SD_IRQHandler evaluates the level-triggered
+     TXFIFOHE/RXFIFOHF branches before the error branch in its else-if chain, so
+     the error branch is never reached and the interrupt refires forever. The
+     error path also did not mask the level-triggered FIFO interrupts.
+     Impacted file:
+      stm32cube/stm32h7xx/drivers/src/stm32h7xx_hal_sd.c
+     ST Internal Reference: 3b58a19a83364710b42ee9402fda1e6b
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32h7xx/drivers/src/stm32h7xx_hal_sd.c
+++ b/stm32cube/stm32h7xx/drivers/src/stm32h7xx_hal_sd.c
@@ -1540,7 +1540,12 @@ void HAL_SD_IRQHandler(SD_HandleTypeDef *hsd)
   uint32_t context = hsd->Context;
 
   /* Check for SDMMC interrupt flags */
-  if ((__HAL_SD_GET_FLAG(hsd, SDMMC_FLAG_RXFIFOHF) != RESET) && ((context & SD_CONTEXT_IT) != 0U))
+  /* Do not service the FIFOs while a data error flag is pending: the FIFO
+     flags are level-triggered and would otherwise keep re-entering this
+     handler, so the error branch below would never be reached */
+  if ((__HAL_SD_GET_FLAG(hsd, SDMMC_FLAG_RXFIFOHF) != RESET) && ((context & SD_CONTEXT_IT) != 0U) &&
+      (__HAL_SD_GET_FLAG(hsd, SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_RXOVERR |
+                         SDMMC_FLAG_TXUNDERR) == RESET))
   {
     SD_Read_IT(hsd);
   }
@@ -1640,7 +1645,9 @@ void HAL_SD_IRQHandler(SD_HandleTypeDef *hsd)
     }
   }
 
-  else if ((__HAL_SD_GET_FLAG(hsd, SDMMC_FLAG_TXFIFOHE) != RESET) && ((context & SD_CONTEXT_IT) != 0U))
+  else if ((__HAL_SD_GET_FLAG(hsd, SDMMC_FLAG_TXFIFOHE) != RESET) && ((context & SD_CONTEXT_IT) != 0U) &&
+           (__HAL_SD_GET_FLAG(hsd, SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_RXOVERR |
+                              SDMMC_FLAG_TXUNDERR) == RESET))
   {
     SD_Write_IT(hsd);
   }
@@ -1669,9 +1676,11 @@ void HAL_SD_IRQHandler(SD_HandleTypeDef *hsd)
     /* Clear All flags */
     __HAL_SD_CLEAR_FLAG(hsd, SDMMC_STATIC_DATA_FLAGS);
 
-    /* Disable all interrupts */
+    /* Disable all interrupts, including the level-triggered FIFO ones which
+       cannot be cleared and would otherwise keep the IRQ line asserted */
     __HAL_SD_DISABLE_IT(hsd, SDMMC_IT_DATAEND | SDMMC_IT_DCRCFAIL | SDMMC_IT_DTIMEOUT | \
-                        SDMMC_IT_TXUNDERR | SDMMC_IT_RXOVERR);
+                        SDMMC_IT_TXUNDERR | SDMMC_IT_RXOVERR | SDMMC_IT_TXFIFOHE | \
+                        SDMMC_IT_RXFIFOHF);
 
     __SDMMC_CMDTRANS_DISABLE(hsd->Instance);
     hsd->Instance->DCTRL |= SDMMC_DCTRL_FIFORST;


### PR DESCRIPTION
When a data error (TXUNDERR, RXOVERR, DCRCFAIL, DTIMEOUT) occurs during an
interrupt-mode SD transfer, `HAL_SD_IRQHandler` evaluates the level-triggered
`TXFIFOHE`/`RXFIFOHF` branches before the error branch of its `else if`
chain. Since those FIFO flags are level-triggered and cannot be cleared by
software, the handler keeps re-entering the FIFO branch, the error branch is
never reached, and the interrupt refires forever.

The practical effect is a hard lockup of the whole system: the IRQ starves every
thread, so networking and shell die while the ISR keeps running. The error path
also fails to mask the FIFO interrupts, so even when it does run the IRQ line can
stay asserted.

## How it was found

An SD card on an STM32H747I-DISCO stopped accepting data mid-write (a physical
card fault; only a power cycle recovers it). The resulting `TXUNDERR` left
`TXFIFOHE` asserted, and the board became completely unresponsive. Diagnosed via
SWD: the CPU was permanently inside `HAL_SD_IRQHandler`.

The fix has been running in production firmware since 2026-07-10, including a
10-minute stress test writing 512 KB blocks continuously while acquiring sensor
data, with no regression.

## The fix

- skip FIFO servicing while any data error flag is pending, so the error branch
  is reachable;
- add `TXFIFOHE`/`RXFIFOHF` to the disable mask on the error path.

I have added a patch entry to `stm32cube/stm32h7xx/README`, since this is the
repository convention.

## Note on other series

Only STM32H7 is changed here, because that is what I could test. However, the
**identical construct** is present in the `HAL_SD_IRQHandler` of ten other
series in this repository:

`stm32f7xx`, `stm32h5xx`, `stm32h7rsxx`, `stm32l4xx`, `stm32l5xx`,
`stm32mp13xx`, `stm32mp2xx`, `stm32n6xx`, `stm32u3xx`, `stm32u5xx`

I could extend the patch to all of them if you prefer a single fan-out change
(as was done for `HAL_DFSDM_IRQHandler` in d3a20294), but I did not want
to submit untested changes for hardware I do not have and am not able to test.

I have no ST internal bug number for this; please let me know if it should also
be reported through the STM32CubeH7 repository.

