### PR TITLE
stm32cube: h5: add LL USB fix for OTG_FS on H5E5/H5F5

### DIFF
--- a/stm32cube/stm32h5xx/README
+++ b/stm32cube/stm32h5xx/README
@@ -97,4 +97,14 @@ Patch List:
        drivers/src/stm32h5xx_hal_mdf.c
      ST Internal Reference: HAL1-27843
 
+   *Fix incomplete OTGFS initialization on H5E5/H5F5
+      Due to an implementation defect, the USB_CoreInit() implementation
+      did not enable the FS PHY on STM32H5 lines with both OTG_FS and OTG_HS
+      (i.e., H5E5/H5F5), preventing usage of OTG_FS entirely. This fix is
+      cherry-picked from stm32h5xx-hal-driver. The original fix commit is
+      e73ad7e5c09abb40bed787b49068fb1f87343c19.
+     Impacted file:
+      stm32cube/stm32h5xx/drivers/src/stm32h5xx_ll_usb.c
+     ST Internal Reference: HAL1-27918
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32h5xx/drivers/src/stm32h5xx_ll_usb.c
+++ b/stm32cube/stm32h5xx/drivers/src/stm32h5xx_ll_usb.c
@@ -86,46 +86,49 @@ static HAL_StatusTypeDef USB_CoreReset(USB_OTG_GlobalTypeDef *USBx);
 HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg)
 {
   HAL_StatusTypeDef ret;
-#if defined (STM32H5F5xx) || defined (STM32H5E5xx)
-  if (cfg.phy_itface == USB_OTG_HS_EMBEDDED_PHY)
+#if defined (USB_OTG_HS)
+  if (USBx == USB_OTG_HS)
   {
-    /* Init The UTMI Interface */
-    USBx->GUSBCFG &= ~(USB_OTG_GUSBCFG_TSDPS);
-  }
+    if (cfg.phy_itface == USB_OTG_HS_EMBEDDED_PHY)
+    {
+      /* Init The UTMI Interface */
+      USBx->GUSBCFG &= ~(USB_OTG_GUSBCFG_TSDPS);
+    }
 
-  /* Reset after a PHY select */
-  ret = USB_CoreReset(USBx);
+    /* Reset after a PHY select */
+    ret = USB_CoreReset(USBx);
 
-  if (cfg.dma_enable == 1U)
-  {
-    /* make sure to reserve 18 fifo Locations for DMA buffers */
-    USBx->GDFIFOCFG &= ~(0xFFFFUL << 16);
-    USBx->GDFIFOCFG |= 0x3EEUL << 16;
+    if (cfg.dma_enable == 1U)
+    {
+      /* make sure to reserve 18 fifo Locations for DMA buffers */
+      USBx->GDFIFOCFG &= ~(0xFFFFUL << 16);
+      USBx->GDFIFOCFG |= 0x3EEUL << 16;
 
-    USBx->GAHBCFG &= ~(USB_OTG_GAHBCFG_HBSTLEN);
-    USBx->GAHBCFG |= USB_OTG_GAHBCFG_HBSTLEN_INCR4;
-    USBx->GAHBCFG |= USB_OTG_GAHBCFG_DMAEN;
-  }
-
-#else
-
-  /* Select FS Embedded PHY */
-  USBx->GUSBCFG |= USB_OTG_GUSBCFG_PHYSEL;
-
-  /* Reset after a PHY select */
-  ret = USB_CoreReset(USBx);
-
-  if (cfg.battery_charging_enable == 0U)
-  {
-    /* Activate the USB Transceiver */
-    USBx->GCCFG |= USB_OTG_GCCFG_PWRDWN;
+      USBx->GAHBCFG &= ~(USB_OTG_GAHBCFG_HBSTLEN);
+      USBx->GAHBCFG |= USB_OTG_GAHBCFG_HBSTLEN_INCR4;
+      USBx->GAHBCFG |= USB_OTG_GAHBCFG_DMAEN;
+    }
   }
   else
+#endif /* defined (USB_OTG_HS) */
   {
-    /* Deactivate the USB Transceiver */
-    USBx->GCCFG &= ~(USB_OTG_GCCFG_PWRDWN);
+    /* Select FS Embedded PHY */
+    USBx->GUSBCFG |= USB_OTG_GUSBCFG_PHYSEL;
+
+    /* Reset after a PHY select */
+    ret = USB_CoreReset(USBx);
+
+    if (cfg.battery_charging_enable == 0U)
+    {
+      /* Activate the USB Transceiver */
+      USBx->GCCFG |= USB_OTG_GCCFG_PWRDWN;
+    }
+    else
+    {
+      /* Deactivate the USB Transceiver */
+      USBx->GCCFG &= ~(USB_OTG_GCCFG_PWRDWN);
+    }
   }
-#endif /* defined (STM32H5F5xx) || defined (STM32H5E5xx) */
 
   return ret;
 }


### PR DESCRIPTION
This fix is cherry-picked from upstream stm32h5xx-hal-driver repository: the original commit's hash is e73ad7e5c09abb40bed787b49068fb1f87343c19.

Due to an error in the USB_CoreInit() function, on STM32H5E5 and H5F5 product lines, the OTG_FS PHY was never taken out of power-down mode. As a result, it was impossible to use OTG_FS to perform communication since the PHY was not active. Cherry-pick the fix for this error from upstream while waiting for a future HAL release which integrates the fix directly.