### PR TITLE
stm32cube: break from series search loop once found

### DIFF
--- a/stm32cube/CMakeLists.txt
+++ b/stm32cube/CMakeLists.txt
@@ -126,6 +126,7 @@ foreach(series ${supported_series})
     endif()
 
     add_subdirectory(${cube_dir})
+    break()
   endif()
 endforeach()
 


### PR DESCRIPTION
Once we found the SoC series selected in Zephyr and added it to the build, break out of the search loop immediately to avoid wasting time.