### PR TITLE
Add SDIO for STM32F1

### DIFF
--- a/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
@@ -490,6 +490,57 @@
 		pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 	};
 
+	/* SDIO */
+	/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {
+		pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d5_pb9: sdio_d5_pb9 {
+		pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d6_pc6: sdio_d6_pc6 {
+		pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d7_pc7: sdio_d7_pc7 {
+		pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d0_pc8: sdio_d0_pc8 {
+		pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d1_pc9: sdio_d1_pc9 {
+		pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d2_pc10: sdio_d2_pc10 {
+		pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d3_pc11: sdio_d3_pc11 {
+		pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_ck_pc12: sdio_ck_pc12 {
+		pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_cmd_pd2: sdio_cmd_pd2 {
+		pinmux = <STM32F1_PINMUX('D', 2, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
 	/* SPI_MASTER_MISO */
 	/omit-if-no-ref/ spi1_miso_master_pa6: spi1_miso_master_pa6 {
 		pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;

--- a/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
@@ -474,6 +474,57 @@
 		pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 	};
 
+	/* SDIO */
+	/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {
+		pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d5_pb9: sdio_d5_pb9 {
+		pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d6_pc6: sdio_d6_pc6 {
+		pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d7_pc7: sdio_d7_pc7 {
+		pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d0_pc8: sdio_d0_pc8 {
+		pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d1_pc9: sdio_d1_pc9 {
+		pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d2_pc10: sdio_d2_pc10 {
+		pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d3_pc11: sdio_d3_pc11 {
+		pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_ck_pc12: sdio_ck_pc12 {
+		pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_cmd_pd2: sdio_cmd_pd2 {
+		pinmux = <STM32F1_PINMUX('D', 2, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
 	/* SPI_MASTER_MISO */
 	/omit-if-no-ref/ spi1_miso_master_pa6: spi1_miso_master_pa6 {
 		pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;

--- a/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
@@ -490,6 +490,57 @@
 		pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 	};
 
+	/* SDIO */
+	/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {
+		pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d5_pb9: sdio_d5_pb9 {
+		pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d6_pc6: sdio_d6_pc6 {
+		pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d7_pc7: sdio_d7_pc7 {
+		pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d0_pc8: sdio_d0_pc8 {
+		pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d1_pc9: sdio_d1_pc9 {
+		pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d2_pc10: sdio_d2_pc10 {
+		pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d3_pc11: sdio_d3_pc11 {
+		pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_ck_pc12: sdio_ck_pc12 {
+		pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_cmd_pd2: sdio_cmd_pd2 {
+		pinmux = <STM32F1_PINMUX('D', 2, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
 	/* SPI_MASTER_MISO */
 	/omit-if-no-ref/ spi1_miso_master_pa6: spi1_miso_master_pa6 {
 		pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;

--- a/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
@@ -614,6 +614,57 @@
 		pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 	};
 
+	/* SDIO */
+	/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {
+		pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d5_pb9: sdio_d5_pb9 {
+		pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d6_pc6: sdio_d6_pc6 {
+		pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d7_pc7: sdio_d7_pc7 {
+		pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d0_pc8: sdio_d0_pc8 {
+		pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d1_pc9: sdio_d1_pc9 {
+		pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d2_pc10: sdio_d2_pc10 {
+		pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d3_pc11: sdio_d3_pc11 {
+		pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_ck_pc12: sdio_ck_pc12 {
+		pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_cmd_pd2: sdio_cmd_pd2 {
+		pinmux = <STM32F1_PINMUX('D', 2, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
 	/* SPI_MASTER_MISO */
 	/omit-if-no-ref/ spi1_miso_master_pa6: spi1_miso_master_pa6 {
 		pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;

--- a/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
@@ -614,6 +614,57 @@
 		pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 	};
 
+	/* SDIO */
+	/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {
+		pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d5_pb9: sdio_d5_pb9 {
+		pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d6_pc6: sdio_d6_pc6 {
+		pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d7_pc7: sdio_d7_pc7 {
+		pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d0_pc8: sdio_d0_pc8 {
+		pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d1_pc9: sdio_d1_pc9 {
+		pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d2_pc10: sdio_d2_pc10 {
+		pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d3_pc11: sdio_d3_pc11 {
+		pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_ck_pc12: sdio_ck_pc12 {
+		pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_cmd_pd2: sdio_cmd_pd2 {
+		pinmux = <STM32F1_PINMUX('D', 2, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
 	/* SPI_MASTER_MISO */
 	/omit-if-no-ref/ spi1_miso_master_pa6: spi1_miso_master_pa6 {
 		pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;

--- a/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
@@ -614,6 +614,57 @@
 		pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 	};
 
+	/* SDIO */
+	/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {
+		pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d5_pb9: sdio_d5_pb9 {
+		pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d6_pc6: sdio_d6_pc6 {
+		pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d7_pc7: sdio_d7_pc7 {
+		pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d0_pc8: sdio_d0_pc8 {
+		pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d1_pc9: sdio_d1_pc9 {
+		pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d2_pc10: sdio_d2_pc10 {
+		pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d3_pc11: sdio_d3_pc11 {
+		pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_ck_pc12: sdio_ck_pc12 {
+		pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_cmd_pd2: sdio_cmd_pd2 {
+		pinmux = <STM32F1_PINMUX('D', 2, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
 	/* SPI_MASTER_MISO */
 	/omit-if-no-ref/ spi1_miso_master_pa6: spi1_miso_master_pa6 {
 		pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;

--- a/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
@@ -762,6 +762,57 @@
 		pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 	};
 
+	/* SDIO */
+	/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {
+		pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d5_pb9: sdio_d5_pb9 {
+		pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d6_pc6: sdio_d6_pc6 {
+		pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d7_pc7: sdio_d7_pc7 {
+		pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d0_pc8: sdio_d0_pc8 {
+		pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d1_pc9: sdio_d1_pc9 {
+		pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d2_pc10: sdio_d2_pc10 {
+		pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d3_pc11: sdio_d3_pc11 {
+		pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_ck_pc12: sdio_ck_pc12 {
+		pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_cmd_pd2: sdio_cmd_pd2 {
+		pinmux = <STM32F1_PINMUX('D', 2, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
 	/* SPI_MASTER_MISO */
 	/omit-if-no-ref/ spi1_miso_master_pa6: spi1_miso_master_pa6 {
 		pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;

--- a/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
@@ -762,6 +762,57 @@
 		pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 	};
 
+	/* SDIO */
+	/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {
+		pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d5_pb9: sdio_d5_pb9 {
+		pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d6_pc6: sdio_d6_pc6 {
+		pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d7_pc7: sdio_d7_pc7 {
+		pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d0_pc8: sdio_d0_pc8 {
+		pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d1_pc9: sdio_d1_pc9 {
+		pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d2_pc10: sdio_d2_pc10 {
+		pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d3_pc11: sdio_d3_pc11 {
+		pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_ck_pc12: sdio_ck_pc12 {
+		pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_cmd_pd2: sdio_cmd_pd2 {
+		pinmux = <STM32F1_PINMUX('D', 2, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
 	/* SPI_MASTER_MISO */
 	/omit-if-no-ref/ spi1_miso_master_pa6: spi1_miso_master_pa6 {
 		pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;

--- a/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
@@ -762,6 +762,57 @@
 		pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 	};
 
+	/* SDIO */
+	/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {
+		pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d5_pb9: sdio_d5_pb9 {
+		pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d6_pc6: sdio_d6_pc6 {
+		pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d7_pc7: sdio_d7_pc7 {
+		pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d0_pc8: sdio_d0_pc8 {
+		pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d1_pc9: sdio_d1_pc9 {
+		pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d2_pc10: sdio_d2_pc10 {
+		pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d3_pc11: sdio_d3_pc11 {
+		pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_ck_pc12: sdio_ck_pc12 {
+		pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_cmd_pd2: sdio_cmd_pd2 {
+		pinmux = <STM32F1_PINMUX('D', 2, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
 	/* SPI_MASTER_MISO */
 	/omit-if-no-ref/ spi1_miso_master_pa6: spi1_miso_master_pa6 {
 		pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;

--- a/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
@@ -762,6 +762,57 @@
 		pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, NO_REMAP)>;
 	};
 
+	/* SDIO */
+	/omit-if-no-ref/ sdio_d4_pb8: sdio_d4_pb8 {
+		pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d5_pb9: sdio_d5_pb9 {
+		pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d6_pc6: sdio_d6_pc6 {
+		pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d7_pc7: sdio_d7_pc7 {
+		pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d0_pc8: sdio_d0_pc8 {
+		pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d1_pc9: sdio_d1_pc9 {
+		pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d2_pc10: sdio_d2_pc10 {
+		pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_d3_pc11: sdio_d3_pc11 {
+		pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_ck_pc12: sdio_ck_pc12 {
+		pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
+	/omit-if-no-ref/ sdio_cmd_pd2: sdio_cmd_pd2 {
+		pinmux = <STM32F1_PINMUX('D', 2, ALTERNATE, NO_REMAP)>;
+		slew-rate = "max-speed-50mhz";
+	};
+
 	/* SPI_MASTER_MISO */
 	/omit-if-no-ref/ spi1_miso_master_pa6: spi1_miso_master_pa6 {
 		pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, SPI1_REMAP0)>;

--- a/scripts/genpinctrl/stm32f1-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32f1-pinctrl-config.yaml
@@ -178,6 +178,11 @@
   match: "^RCC_MCO_?(\\d+)?$"
   mode: alternate
 
+- name: SDIO
+  match: "^SDIO_(?:CK|CMD|D[0-7])$"
+  mode: alternate
+  slew-rate: max-speed-50mhz
+
 - name: SPI_MASTER_MISO
   match: "^SPI\\d+_MISO$"
   bias: pull-down


### PR DESCRIPTION
SDIO pins are missing in F1 pinctrl configuration pins. Add them and regenerate the pinctrl.